### PR TITLE
afterthought a comma

### DIFF
--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -1,6 +1,6 @@
 module Yao::Resources
   class Hypervisor < Base
-    friendly_attributes :hypervisor_hostname, :hypervisor_type, :hypervisor_version, :running_vms, :current_workload
+    friendly_attributes :hypervisor_hostname, :hypervisor_type, :hypervisor_version, :running_vms, :current_workload,
                         :vcpus, :vcpus_used,
                         :memory_mb, :memory_mb_used, :free_disk_gb,
                         :local_gb, :local_gb_used, :free_disk_gb


### PR DESCRIPTION
hi!
It was correct the syntax error
```
% ruby test.rb
/usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/yao-0.0.3/lib/yao/resources.rb:21:in `const_get': /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/yao-0.0.3/lib/yao/resources/hypervisor.rb:4: syntax error, unexpected ',', expecting keyword_end (SyntaxError)
                        :vcpus, :vcpus_used,
                               ^
        from /usr/local/var/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/yao-0.0.3/lib/yao/resources.rb:21:in `const_missing'
        from test.rb:9:in `<main>'
```
