### PR TITLE
add resource host

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -14,6 +14,7 @@ module Yao
     autoload :Subnet,            "yao/resources/subnet"
     autoload :Port,              "yao/resources/port"
     autoload :Tenant,            "yao/resources/tenant"
+    autoload :Host,              "yao/resources/host"
 
   end
 

--- a/lib/yao/resources/host.rb
+++ b/lib/yao/resources/host.rb
@@ -1,0 +1,9 @@
+module Yao::Resources
+  class Host < Base
+    friendly_attributes :host_name, :service, :zone
+
+    self.service        = "compute"
+    self.resource_name  = "os-hosts"
+    self.resources_name = "os-hosts"
+  end
+end


### PR DESCRIPTION
hi
It becomes associated with the compute-node and availabilityzone
```
 #<Yao::Resources::Host:0x007ff408ab5a50
  @data=
   {"zone"=>"5ESK12",
    "host_name"=>"comp-node0068.u01.pbcloud.local",
    "service"=>"compute"}>]
```