### PR TITLE
Add resource user

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -15,7 +15,7 @@ module Yao
     autoload :Port,              "yao/resources/port"
     autoload :Tenant,            "yao/resources/tenant"
     autoload :Host,              "yao/resources/host"
-
+    autoload :User,              "yao/resources/user"
   end
 
   def self.const_missing(name)

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -23,8 +23,16 @@ module Yao::Resources
       @service
     end
 
+    def admin=(bool)
+      @admin = bool
+    end
+
     def client
-      Yao.default_client.pool[service]
+      if @admin
+        Yao.default_client.admin_pool[service]
+      else
+        Yao.default_client.pool[service]
+      end
     end
 
     # restful methods

--- a/lib/yao/resources/user.rb
+++ b/lib/yao/resources/user.rb
@@ -1,0 +1,12 @@
+module Yao::Resources
+  class User < Base
+    friendly_attributes :name, :email, :enabled, :id
+
+    alias enabled? enabled
+
+    self.service        = "identity"
+    self.resource_name  = "user"
+    self.resources_name = "users"
+    self.admin          = true
+  end
+end

--- a/lib/yao/resources/user.rb
+++ b/lib/yao/resources/user.rb
@@ -8,5 +8,9 @@ module Yao::Resources
     self.resource_name  = "user"
     self.resources_name = "users"
     self.admin          = true
+
+    def self.get_by_name(name)
+      self.list.find {|user| user.name == name }
+    end
   end
 end

--- a/lib/yao/token.rb
+++ b/lib/yao/token.rb
@@ -47,16 +47,15 @@ module Yao
       return unless _endpoints
 
       _endpoints.each do |endpoint_data|
-        key = endpoint_data["type"]
-        value = if d = endpoint_data["endpoints"].first
-                  d["publicURL"]
-                else
-                  nil
-                end
-        if value
-          @endpoints[key] = value
-        end
+        type = endpoint_data["type"]
+        endpoint = endpoint_data["endpoints"].first
+        urls = {}
+        urls[:public_url] = endpoint["publicURL"] if endpoint["publicURL"]
+        urls[:admin_url]  = endpoint["adminURL"]  if endpoint["adminURL"]
+
+        @endpoints[type] = urls
       end
+
       Yao.default_client.register_endpoints(@endpoints, token: self)
     end
   end


### PR DESCRIPTION
This PR adds new resource `User`.

The main change is internally introducing `admin_pool` which contains faraday clients which url is `adminURL`. It is required to issue request to [identity admin](http://developer.openstack.org/api-ref-identity-admin-v2.html) API instead of identity API to get or manipulate `User` resource.
