### PR TITLE
Add Role resource

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -16,6 +16,7 @@ module Yao
     autoload :Tenant,            "yao/resources/tenant"
     autoload :Host,              "yao/resources/host"
     autoload :User,              "yao/resources/user"
+    autoload :Role,              "yao/resources/role"
   end
 
   def self.const_missing(name)

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -27,6 +27,14 @@ module Yao::Resources
       @admin = bool
     end
 
+    def resources_path
+      @resources_path || resources_name
+    end
+
+    def resources_path=(path)
+      @resources_path = path.sub(%r!^\/!, "")
+    end
+
     def client
       if @admin
         Yao.default_client.admin_pool[service]
@@ -37,18 +45,18 @@ module Yao::Resources
 
     # restful methods
     def list(query={})
-      return_resources(GET(resources_name, query).body[resources_name_in_json])
+      return_resources(GET(resources_path, query).body[resources_name_in_json])
     end
 
     def list_detail(query={})
-      return_resources(GET([resources_name, "detail"].join("/"), query).body[resources_name_in_json])
+      return_resources(GET([resources_path, "detail"].join("/"), query).body[resources_name_in_json])
     end
 
     def get(id_or_permalink, query={})
       res = if id_or_permalink =~ /^https?:\/\//
               GET(id_or_permalink, query)
             else
-              GET([resources_name, id_or_permalink].join("/"), query)
+              GET([resources_path, id_or_permalink].join("/"), query)
             end
       return_resource(res.body[resource_name_in_json])
     end
@@ -58,7 +66,7 @@ module Yao::Resources
       params = {
         resource_name_in_json => resource_params
       }
-      res = POST(resources_name) do |req|
+      res = POST(resources_path) do |req|
         req.body = params.to_json
         req.headers['Content-Type'] = 'application/json'
       end
@@ -69,7 +77,7 @@ module Yao::Resources
       params = {
         resource_name_in_json => resource_params
       }
-      res = PUT([resources_name, id].join("/")) do |req|
+      res = PUT([resources_path, id].join("/")) do |req|
         req.body = params.to_json
         req.headers['Content-Type'] = 'application/json'
       end
@@ -77,7 +85,7 @@ module Yao::Resources
     end
 
     def destroy(id)
-      res = DELETE([resources_name, id].join("/"))
+      res = DELETE([resources_path, id].join("/"))
       res.body
     end
 

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -1,6 +1,6 @@
 module Yao::Resources
   class Role < Base
-    friendly_attributes :name, :id
+    friendly_attributes :name, :description, :id
 
     self.service        = "identity"
     self.resource_name  = "role"

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -1,0 +1,11 @@
+module Yao::Resources
+  class Role < Base
+    friendly_attributes :name, :id
+
+    self.service        = "identity"
+    self.resource_name  = "role"
+    self.resources_name = "roles"
+    self.resources_path = "/OS-KSADM/roles"
+    self.admin          = true
+  end
+end


### PR DESCRIPTION
This introduces an new resource `Role`.

Due to the request path `/OS-KSADM/roles` has special prefix `/OS-KSADM`, this PR involves addition of `resources_path`. Now we can specify the path like [this](https://github.com/Joe-noh/yao/blob/05adcd370b8099df81787ba466537108fb758bd7/lib/yao/resources/role.rb).

`resources_path` is same as `resources_name` by default, so this change doesn't affect other resources.