### PR TITLE
Access tenant API as admin

### DIFF
--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -43,6 +43,17 @@ module Yao::Resources
       end
     end
 
+    def as_member(&blk)
+      if @admin
+        @admin = false
+        result = yield(blk)
+        @admin = true
+        result
+      else
+        yield blk
+      end
+    end
+
     # restful methods
     def list(query={})
       return_resources(GET(resources_path, query).body[resources_name_in_json])

--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -14,11 +14,7 @@ module Yao::Resources
       alias find_by_name get_by_name
 
       def accessible
-        @admin = false
-        tenants = self.list
-        @admin = true
-
-        tenants
+        as_member { self.list }
       end
     end
   end

--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -6,5 +6,20 @@ module Yao::Resources
     self.resource_name  = "tenant"
     self.resources_name = "tenants"
     self.admin          = true
+
+    class << self
+      def get_by_name(name)
+        self.get("", name: name)
+      end
+      alias find_by_name get_by_name
+
+      def granted
+        @admin = false
+        tenants = self.list
+        @admin = true
+
+        tenants
+      end
+    end
   end
 end

--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -5,5 +5,6 @@ module Yao::Resources
     self.service        = "identity"
     self.resource_name  = "tenant"
     self.resources_name = "tenants"
+    self.admin          = true
   end
 end

--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -13,7 +13,7 @@ module Yao::Resources
       end
       alias find_by_name get_by_name
 
-      def granted
+      def accessible
         @admin = false
         tenants = self.list
         @admin = true


### PR DESCRIPTION
**Note: This pull request contains backward incompatibility.**

This PR changes behavior of `Yao::Tenant.list`. The method was used to get the list of tenants which the user can access to. But the name `list` seems to fetch all tenants regardless of access rights. So following changes were made.

- add `Yao::Tenant.accessible` which behaves like old `Yao::Tenant.list`.
- make methods in `Yao::Tenant` access [admin API](http://developer.openstack.org/api-ref-identity-admin-v2.html) then `list` returns an array of all tenants.
- In addition, `Yao::Tenant.(get|find)_by_name` for convenience.