### PR TITLE
Grant and revoke role

### DIFF
--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -20,9 +20,16 @@ Faraday::Request.register_middleware os_token: -> { Faraday::Request::OSToken }
 class Faraday::Response::OSDumper < Faraday::Response::Middleware
   def on_complete(env)
     require 'pp'
+
+    body = if env.response_headers["content-type"] == "application/json"
+             JSON.parse(env.body)
+           else
+             env.body
+           end
+
     params = [
       env.url.to_s,
-      JSON.parse(env.body),
+      body,
       env.request_headers,
       env.response_headers,
       env.method,

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -19,9 +19,7 @@ module Yao::Resources
         user   = Yao::User.get_by_name(to)
         tenant = Yao::Tenant.get_by_name(on)
 
-        client.put path_for_grant_revoke(tenant, user, role) do |req|
-          req.headers['Content-Type'] = 'application/json'
-        end
+        PUT path_for_grant_revoke(tenant, user, role)
       end
 
       def revoke(role_name, from:, on:)
@@ -29,9 +27,7 @@ module Yao::Resources
         user   = Yao::User.get_by_name(from)
         tenant = Yao::Tenant.get_by_name(on)
 
-        client.delete path_for_grant_revoke(tenant, user, role) do |req|
-          req.headers['Content-Type'] = 'application/json'
-        end
+        DELETE path_for_grant_revoke(tenant, user, role)
       end
 
       private

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -27,7 +27,12 @@ module Yao::Resources
         user   = Yao::User.get_by_name(from)
         tenant = Yao::Tenant.get_by_name(on)
 
-        DELETE path_for_grant_revoke(tenant, user, role)
+        begin
+          DELETE path_for_grant_revoke(tenant, user, role)
+        rescue JSON::ParserError
+          # ParserError raises on debug mode because this OpenStack API returns
+          # empty string as response body. But this is expected behavior.
+        end
       end
 
       private

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -27,12 +27,7 @@ module Yao::Resources
         user   = Yao::User.get_by_name(from)
         tenant = Yao::Tenant.get_by_name(on)
 
-        begin
-          DELETE path_for_grant_revoke(tenant, user, role)
-        rescue JSON::ParserError
-          # ParserError raises on debug mode because this OpenStack API returns
-          # empty string as response body. But this is expected behavior.
-        end
+        DELETE path_for_grant_revoke(tenant, user, role)
       end
 
       private

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -24,6 +24,16 @@ module Yao::Resources
         end
       end
 
+      def revoke(role_name, from:, on:)
+        role   = Yao::Role.get_by_name(role_name)
+        user   = Yao::User.get_by_name(from)
+        tenant = Yao::Tenant.get_by_name(on)
+
+        client.delete path_for_grant_revoke(tenant, user, role) do |req|
+          req.headers['Content-Type'] = 'application/json'
+        end
+      end
+
       private
 
       def path_for_grant_revoke(tenant, user, role)

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -13,6 +13,22 @@ module Yao::Resources
         self.list.find {|role| role.name == name }
       end
       alias find_by_name get_by_name
+
+      def grant(role_name, to:, on:)
+        role   = Yao::Role.get_by_name(role_name)
+        user   = Yao::User.get_by_name(to)
+        tenant = Yao::Tenant.get_by_name(on)
+
+        client.put path_for_grant_revoke(tenant, user, role) do |req|
+          req.headers['Content-Type'] = 'application/json'
+        end
+      end
+
+      private
+
+      def path_for_grant_revoke(tenant, user, role)
+        ["tenants", tenant.id, "users", user.id, "roles", "OS-KSADM", role.id].join("/")
+      end
     end
   end
 end


### PR DESCRIPTION
Two methods, `grant` and `revoke`, are implemented in this pull-request.

```ruby
# usage

Yao::Role.grant("the_role", to: "the_user", on: "the_tenant")
Yao::Role.revoke("the_role", from: "the_user", on: "the_tenant")
```