### PR TITLE
List roles for a user

### DIFF
--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -58,6 +58,15 @@ module Yao::Resources
       end
     end
 
+    def with_resources_path(path, &blk)
+      original = @resources_path
+      @resources_path = path
+      result = yield(blk)
+      @resources_path = original
+
+      result
+    end
+
     # restful methods
     def list(query={})
       json = GET(resources_path, query).body

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -14,6 +14,14 @@ module Yao::Resources
       end
       alias find_by_name get_by_name
 
+      def list_for_user(user_name, on:)
+        user   = Yao::User.get_by_name(user_name)
+        tenant = Yao::Tenant.get_by_name(on)
+        path = ["tenants", tenant.id, "users", user.id, "roles"].join("/")
+
+        with_resources_path(path) { self.list }
+      end
+
       def grant(role_name, to:, on:)
         role   = Yao::Role.get_by_name(role_name)
         user   = Yao::User.get_by_name(to)


### PR DESCRIPTION
This PR adds following method.

```ruby
Yao::Role.list_for_user("the_user", on: "the_tenant")
```

To implement this method, `with_resources_path` was implemented too. This evaluates given block overriding `@resources_path` with given path.