### PR TITLE
Add request header 'Accept: application/json' to any request

### DIFF
--- a/lib/yao/client.rb
+++ b/lib/yao/client.rb
@@ -44,8 +44,8 @@ module Yao
 
       def client_generator_hook
         lambda do |f, token|
+          f.request :accept, 'application/json'
           f.request :url_encoded
-          f.request :json
 
           if token
             f.request :os_token, token

--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -1,5 +1,18 @@
 require 'faraday'
 
+class Faraday::Request::Accept
+  def initialize(app, accept=nil)
+    @app = app
+    @accept = accept || 'application/json'
+  end
+
+  def call(env)
+    env[:request_headers]['Accept'] = @accept
+    @app.call(env)
+  end
+end
+Faraday::Request.register_middleware accept: -> { Faraday::Request::Accept }
+
 class Faraday::Request::OSToken
   def initialize(app, token)
     @app = app

--- a/test/yao/test_client.rb
+++ b/test/yao/test_client.rb
@@ -9,8 +9,8 @@ class TestClient < Test::Unit::TestCase
     assert { cli.url_prefix.to_s == "http://cool-api.example.com:12345/v3.0" }
 
     handlers = [
+      Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
-      FaradayMiddleware::EncodeJson,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
       Faraday::Adapter::NetHttp
@@ -21,8 +21,8 @@ class TestClient < Test::Unit::TestCase
   def test_gen_with_token
     cli = Yao::Client.gen_client("http://cool-api.example.com:12345/v3.0", token: "deadbeaf")
     handlers = [
+      Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
-      FaradayMiddleware::EncodeJson,
       Faraday::Request::OSToken,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
@@ -36,8 +36,8 @@ class TestClient < Test::Unit::TestCase
 
     cli = Yao::Client.gen_client("http://cool-api.example.com:12345/v3.0")
     handlers = [
+      Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
-      FaradayMiddleware::EncodeJson,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
       Faraday::Response::Logger,


### PR DESCRIPTION
This header is required to make ceilometer 2.0 API return JSON.

http://docs.openstack.org/developer/ceilometer/webapi/v2.html