### PR TITLE
Add 2.3.0-preview1 test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 rvm:
   - 2.1.7
   - 2.2.3
+  - 2.3.0-preview1
 
 install: bundle install --path vendor/bundle
 


### PR DESCRIPTION
2.3.0-preview1 seems to be available in rvm

- https://github.com/rvm/rvm/commit/064daad2ed13fc0b34a1020e087a01dcaecfb996