### PR TITLE
Ceilometer resources

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -20,7 +20,7 @@ module Yao
 
     autoload :Resource,          "yao/resources/resource"
     autoload :Meter,             "yao/resources/meter"
-    autoload :Sample,            "yao/resources/sample"
+    autoload :OldSample,         "yao/resources/old_sample"
   end
 
   def self.const_missing(name)

--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -21,6 +21,7 @@ module Yao
     autoload :Resource,          "yao/resources/resource"
     autoload :Meter,             "yao/resources/meter"
     autoload :OldSample,         "yao/resources/old_sample"
+    autoload :Sample,            "yao/resources/sample"
   end
 
   def self.const_missing(name)

--- a/lib/yao/resources/meter.rb
+++ b/lib/yao/resources/meter.rb
@@ -11,7 +11,7 @@ module Yao::Resources
     end
 
     def tenant
-      @tenant ||= Yao::User.get(project_id)
+      @tenant ||= Yao::Tenant.get(project_id)
     end
 
     def user

--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -30,8 +30,13 @@ module Yao::Resources
 
     # get /v2/meters/{id} returns samples!
     def self.list(meter_name, query={})
-      json = GET("meters/#{meter_name}", query).body
-      return_resources(json)
+      cache_key = query.values.join
+      cache[cache_key] = GET("meters/#{meter_name}", query).body unless cache[cache_key]
+      return_resources(cache[cache_key])
+    end
+
+    def self.cache
+      @@_cache ||= {}
     end
 
     # TODO: implement `def self.create'

--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -29,12 +29,8 @@ module Yao::Resources
     self.api_version    = "v2"
 
     # get /v2/meters/{id} returns samples!
-    def self.list(id_or_url, query={})
-      json = if id_or_url =~ /^https?:\/\//
-               GET(id_or_url).body
-             else
-               GET("meters/#{id_or_url}", query).body
-             end
+    def self.list(meter_name, query={})
+      json = GET("meters/#{meter_name}", query).body
       return_resources(json)
     end
 

--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -1,5 +1,5 @@
 module Yao::Resources
-  class Sample < Base
+  class OldSample < Base
     friendly_attributes :counter_name, :counter_type, :counter_unit, :counter_volume,
                         :message_id, :project_id, :resource_id, :timestamp, :resource_metadata, :user_id
                         :source

--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -18,7 +18,7 @@ module Yao::Resources
     end
 
     def tenant
-      @tenant ||= Yao::User.get(project_id)
+      @tenant ||= Yao::Tenant.get(project_id)
     end
 
     def user

--- a/lib/yao/resources/sample.rb
+++ b/lib/yao/resources/sample.rb
@@ -1,4 +1,4 @@
-module Yao::Resource
+module Yao::Resources
   class Sample < Base
     friendly_attributes :id, :metadata, :meter,
                         :source, :type, :unit, :volume
@@ -23,8 +23,8 @@ module Yao::Resource
       @user ||= Yao::User.get(user_id)
     end
 
-    self.service        = "samples"
+    self.service        = "metering"
     self.api_version    = "v2"
-
+    self.resources_name = "samples"
   end
 end

--- a/lib/yao/resources/sample.rb
+++ b/lib/yao/resources/sample.rb
@@ -1,0 +1,30 @@
+module Yao::Resource
+  class Sample < Base
+    friendly_attributes :id, :metadata, :meter,
+                        :source, :type, :unit, :volume
+
+    def recorded_at
+      Time.parse(self["recorded_at"])
+    end
+
+    def timestamp
+      Time.parse(self["timestamp"])
+    end
+
+    def resource
+      @resource ||= Yao::Resource.get(resource_id)
+    end
+
+    def tenant
+      @tenant ||= Yao::Tenant.get(project_id)
+    end
+
+    def user
+      @user ||= Yao::User.get(user_id)
+    end
+
+    self.service        = "samples"
+    self.api_version    = "v2"
+
+  end
+end

--- a/lib/yao/resources/sample.rb
+++ b/lib/yao/resources/sample.rb
@@ -2,6 +2,7 @@ module Yao::Resources
   class Sample < Base
     friendly_attributes :id, :metadata, :meter,
                         :source, :type, :unit, :volume
+                        :resouce_id, :tenant_id, :user_id
 
     def recorded_at
       Time.parse(self["recorded_at"])

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -21,6 +21,11 @@ module Yao::Resources
     self.service        = "compute"
     self.resource_name  = "server"
     self.resources_name = "servers"
+
+    def old_samples(counter_name: nil, query: {})
+      Yao::OldSample.list(counter_name, query).select{|os| os.resource_metadata["instance_id"] == id}
+    end
+
     def self.start(id)
       action(id, "os-start" => nil)
     end

--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -8,6 +8,14 @@ module Yao::Resources
     self.admin          = true
     self.return_single_on_querying = true
 
+    def meters
+      @meters ||= Yao::Meter.list({'q.field': 'project_id', 'q.op': 'eq', 'q.value': id})
+    end
+
+    def meters_by_name(meter_name)
+      meters.select{|m| m.name == meter_name}
+    end
+
     class << self
       def get_by_name(name)
         self.list(name: name)


### PR DESCRIPTION
I added ceilometer resources named sample and statistics.

Usage sample:

```rb
# to get network.outgoing.bytes samples after 11/15/2015
$ Yao::OldSample.list('network.outgoing.bytes', {'q.field': 'timestamp', 'q.op': 'gt', 'q.value': '2015-11-24T00:00:00'})
# to get network.outgoing.bytes samples on specific server after 11/15/2015
$ Yao::Server.list.first.old_samples(counter_name: 'network.outgoing.bytes', query:  {'q.field': 'timestamp', 'q.op': 'gt', 'q.value': '2015-11-24T00:00:00'})
```

Limitation:

I couldn't handle multiple condition of metering query like this

```rb
Yao::OldSample.list('network.outgoing.bytes', {'q': [{'field': 'timestamp', 'op': 'gt', 'value': '2015-11-24T00:00:00'}, {'field': 'timestamp', 'op': 'lt', 'value': '2015-11-25T00:00:00'}]})
```

see details http://docs.openstack.org/developer/ceilometer/webapi/v2.html#functional-examples