### PR TITLE
introduce Yao::Tenant#servers

### DIFF
--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -8,6 +8,10 @@ module Yao::Resources
     self.admin          = true
     self.return_single_on_querying = true
 
+    def servers
+      @servers ||= Yao::Server.list(all_tenants: 1).select{|s| s.tenant_id == id }
+    end
+
     class << self
       def get_by_name(name)
         self.list(name: name)


### PR DESCRIPTION
I need to calculate server resource each tenants. but `Yao::Server.list` returns only servers on current `OS_TENANT`. I added `Yao::Tenant#servers` using all_tenants param for getting to server collection.