### PR TITLE
Fix correct results for Yao::Tenant#servers

### DIFF
--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -9,7 +9,7 @@ module Yao::Resources
     self.return_single_on_querying = true
 
     def servers
-      @servers ||= Yao::Server.list(all_tenants: 1).select{|s| s.tenant_id == id }
+      @servers ||= Yao::Server.list_detail(all_tenants: 1).select{|s| s.tenant_id == id }
     end
 
     def meters


### PR DESCRIPTION
Yao::Tenant#servers returns empty array always. It's caused that Yao::Server.list only returns name, resource id and resource link.

I fixed `Yao::Tenant#servers` using `Yao::Server.list_detail`