### PR TITLE
Fix return value using Yao::OldSample.list

### DIFF
--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -30,7 +30,7 @@ module Yao::Resources
 
     # get /v2/meters/{id} returns samples!
     def self.list(meter_name, query={})
-      cache_key = [meter_name, *query].values.join
+      cache_key = [meter_name, *query].join
       cache[cache_key] = GET("meters/#{meter_name}", query).body unless cache[cache_key]
       return_resources(cache[cache_key])
     end

--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -30,7 +30,7 @@ module Yao::Resources
 
     # get /v2/meters/{id} returns samples!
     def self.list(meter_name, query={})
-      cache_key = query.values.join
+      cache_key = [meter_name, *query].values.join
       cache[cache_key] = GET("meters/#{meter_name}", query).body unless cache[cache_key]
       return_resources(cache[cache_key])
     end


### PR DESCRIPTION
Fix return values using `Yao::OldSample.list`. You got always same results with same query and different meter.
