### PR TITLE
`{'foo': 10}` is invalid syntax for Ruby 2.1

### DIFF
--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -13,7 +13,7 @@ module Yao::Resources
     end
 
     def meters
-      @meters ||= Yao::Meter.list({'q.field': 'project_id', 'q.op': 'eq', 'q.value': id})
+      @meters ||= Yao::Meter.list({'q.field' => 'project_id', 'q.op' => 'eq', 'q.value' => id})
     end
 
     def meters_by_name(meter_name)


### PR DESCRIPTION
I didn't confirm to work Yao-0.2.5 with Ruby 2.1. I fixed invalid hash syntax for Ruby 2.1