### PR TITLE
Implement read_only and read_only!

### DIFF
--- a/lib/yao.rb
+++ b/lib/yao.rb
@@ -1,6 +1,8 @@
 require "yao/version"
+require 'yao/mode'
 
 module Yao
+  extend Mode
 end
 
 require 'yao/config'

--- a/lib/yao/client.rb
+++ b/lib/yao/client.rb
@@ -69,6 +69,9 @@ module Yao
     Yao::Client.default_client
   end
 
+  Yao.config.param :noop_on_write, false
+  Yao.config.param :raise_on_write, false
+
   Yao.config.param :debug, false
   Yao.config.param :debug_record_response, false
 end

--- a/lib/yao/error.rb
+++ b/lib/yao/error.rb
@@ -1,5 +1,5 @@
 module Yao
-  class GetOnlyViolationError < ::StandardError; end
+  class ReadOnlyViolationError < ::StandardError; end
 
   class ServerError < ::StandardError
     def initialize(message, requested_env)

--- a/lib/yao/error.rb
+++ b/lib/yao/error.rb
@@ -1,4 +1,6 @@
 module Yao
+  class GetOnlyViolationError < ::StandardError; end
+
   class ServerError < ::StandardError
     def initialize(message, requested_env)
       @status = requested_env.status

--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -108,6 +108,8 @@ class Faraday::Response::OSResponseRecorder < Faraday::Response::Middleware
   def on_complete(env)
     require 'pathname'
     root = Pathname.new(File.expand_path('../../../tmp', __FILE__))
+    Dir.mkdir(root) unless File.exist?(root)
+
     path = [env.method.to_s.upcase, env.url.path.gsub('/', '-')].join("-") + ".json"
 
     puts root.join(path)

--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -31,7 +31,7 @@ class Faraday::Request::OSToken
 end
 Faraday::Request.register_middleware os_token: -> { Faraday::Request::OSToken }
 
-class Faraday::Request::GetOnly
+class Faraday::Request::ReadOnly
   def initialize(app)
     @app = app
   end
@@ -40,7 +40,7 @@ class Faraday::Request::GetOnly
     return @app.call(env) if allowed_request?(env)
 
     if Yao.config.raise_on_write
-      raise Yao::GetOnlyViolationError
+      raise Yao::ReadOnlyViolationError
     elsif Yao.config.noop_on_write
       env
     else
@@ -62,7 +62,7 @@ class Faraday::Request::GetOnly
     end
   end
 end
-Faraday::Request.register_middleware get_only: -> { Faraday::Request::GetOnly }
+Faraday::Request.register_middleware read_only: -> { Faraday::Request::ReadOnly }
 
 class Faraday::Response::OSDumper < Faraday::Response::Middleware
   def on_complete(env)

--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'yao/error'
 
 class Faraday::Request::Accept
   def initialize(app, accept=nil)
@@ -84,7 +85,6 @@ class Faraday::Response::OSResponseRecorder < Faraday::Response::Middleware
 end
 Faraday::Response.register_middleware os_response_recorder: -> { Faraday::Response::OSResponseRecorder }
 
-require 'yao/server_error'
 class Faraday::Response::OSErrorDetector < Faraday::Response::Middleware
   # TODO: Better handling, respecting official doc
   def on_complete(env)

--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -50,14 +50,14 @@ class Faraday::Request::ReadOnly
 
   private
 
+  ALLOWED_REQUESTS = [
+    {method: :post, path: "/v2.0/tokens"}
+  ]
+
   def allowed_request?(env)
     return true if env[:method] == :get
 
-    allowed_requests = [
-      {method: :post, path: "/v2.0/tokens"}
-    ]
-
-    allowed_requests.any? do |allowed|
+    ALLOWED_REQUESTS.any? do |allowed|
       env[:method] == allowed[:method] && env[:url].path == allowed[:path]
     end
   end

--- a/lib/yao/mode.rb
+++ b/lib/yao/mode.rb
@@ -4,16 +4,22 @@ module Yao
       raise unless block_given?
 
       Yao.config.set :raise_on_write, true
-      yield
-      Yao.config.set :raise_on_write, false
+      begin
+        yield
+      ensure
+        Yao.config.set :raise_on_write, false
+      end
     end
 
     def read_only(&blk)
       raise unless block_given?
 
       Yao.config.set :noop_on_write, true
-      yield
-      Yao.config.set :noop_on_write, false
+      begin
+        yield
+      ensure
+        Yao.config.set :noop_on_write, false
+      end
     end
   end
 end

--- a/lib/yao/mode.rb
+++ b/lib/yao/mode.rb
@@ -4,7 +4,7 @@ module Yao
       raise unless block_given?
 
       Yao.config.set :raise_on_write, true
-      yield(blk)
+      yield
       Yao.config.set :raise_on_write, false
     end
 
@@ -12,7 +12,7 @@ module Yao
       raise unless block_given?
 
       Yao.config.set :noop_on_write, true
-      yield(blk)
+      yield
       Yao.config.set :noop_on_write, false
     end
   end

--- a/lib/yao/mode.rb
+++ b/lib/yao/mode.rb
@@ -3,26 +3,32 @@ module Yao
     def read_only!(&blk)
       raise unless block_given?
 
-      before = Yao.config.raise_on_write
+      raise_on_write_org = Yao.config.raise_on_write
+      noop_on_write_org  = Yao.config.noop_on_write
 
+      Yao.config.set :noop_on_write, false if noop_on_write_org
       Yao.config.set :raise_on_write, true
       begin
         yield
       ensure
-        Yao.config.set :raise_on_write, before
+        Yao.config.set :raise_on_write, raise_on_write_org
+        Yao.config.set :noop_on_write,  noop_on_write_org
       end
     end
 
     def read_only(&blk)
       raise unless block_given?
 
-      before = Yao.config.noop_on_write
+      noop_on_write_org  = Yao.config.noop_on_write
+      raise_on_write_org = Yao.config.raise_on_write
 
+      Yao.config.set :raise_on_write, false if raise_on_write_org
       Yao.config.set :noop_on_write, true
       begin
         yield
       ensure
-        Yao.config.set :noop_on_write, before
+        Yao.config.set :noop_on_write,  noop_on_write_org
+        Yao.config.set :raise_on_write, raise_on_write_org
       end
     end
   end

--- a/lib/yao/mode.rb
+++ b/lib/yao/mode.rb
@@ -1,0 +1,19 @@
+module Yao
+  module Mode
+    def read_only!(&blk)
+      raise unless block_given?
+
+      Yao.config.set :raise_on_write, true
+      yield(blk)
+      Yao.config.set :raise_on_write, false
+    end
+
+    def read_only(&blk)
+      raise unless block_given?
+
+      Yao.config.set :noop_on_write, true
+      yield(blk)
+      Yao.config.set :noop_on_write, false
+    end
+  end
+end

--- a/lib/yao/mode.rb
+++ b/lib/yao/mode.rb
@@ -3,22 +3,26 @@ module Yao
     def read_only!(&blk)
       raise unless block_given?
 
+      before = Yao.config.raise_on_write
+
       Yao.config.set :raise_on_write, true
       begin
         yield
       ensure
-        Yao.config.set :raise_on_write, false
+        Yao.config.set :raise_on_write, before
       end
     end
 
     def read_only(&blk)
       raise unless block_given?
 
+      before = Yao.config.noop_on_write
+
       Yao.config.set :noop_on_write, true
       begin
         yield
       ensure
-        Yao.config.set :noop_on_write, false
+        Yao.config.set :noop_on_write, before
       end
     end
   end

--- a/lib/yao/plugins/default_client_generator.rb
+++ b/lib/yao/plugins/default_client_generator.rb
@@ -13,6 +13,8 @@ module Yao::Plugins
         f.request :os_token, token
       end
 
+      f.request :get_only
+
       f.response :os_error_detector
       f.response :json, :content_type => /\bjson$/
 

--- a/lib/yao/plugins/default_client_generator.rb
+++ b/lib/yao/plugins/default_client_generator.rb
@@ -13,7 +13,7 @@ module Yao::Plugins
         f.request :os_token, token
       end
 
-      f.request :get_only
+      f.request :read_only
 
       f.response :os_error_detector
       f.response :json, :content_type => /\bjson$/

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -57,18 +57,18 @@ module Yao::Resources
     def as_member(&blk)
       if @admin
         @admin = false
-        result = yield(blk)
+        result = yield
         @admin = true
         result
       else
-        yield blk
+        yield
       end
     end
 
     def with_resources_path(path, &blk)
       original = @resources_path
       @resources_path = path
-      result = yield(blk)
+      result = yield
       @resources_path = original
 
       result

--- a/test/config.rb
+++ b/test/config.rb
@@ -3,6 +3,8 @@ require 'test/unit/rr'
 require 'power_assert'
 require 'yao'
 
+require 'support/auth_stub'
+
 require 'webmock/test_unit'
 
 WebMock.disable_net_connect!

--- a/test/support/auth_stub.rb
+++ b/test/support/auth_stub.rb
@@ -1,0 +1,117 @@
+module AuthStub
+  def stub_auth_request(auth_url, username, password, tenant)
+    stub_request(:post, "#{auth_url}/v2.0/tokens")
+      .with(
+        body: auth_json(username, password, tenant)
+      ).to_return(
+        :status => 200,
+        :body => response_json(auth_url, username, tenant),
+        :headers => {'Content-Type' => 'application/json'}
+      )
+  end
+
+  private
+
+  def auth_json(username, password, tenant)
+    json = <<-JSON
+{"auth":{"passwordCredentials":{"username":"#{username}","password":"#{password}"},"tenantName":"#{tenant}"}}
+    JSON
+
+    json.strip
+  end
+
+  def response_json(auth_url, username, tenant)
+    <<-JSON
+{
+  "access": {
+    "token": {
+      "issued_at": "#{Time.now.iso8601}",
+      "expires": "#{(Time.now + 3600).utc.iso8601}",
+      "id": "aaaa166533fd49f3b11b1cdce2430000",
+      "tenant": {
+        "description": "Testing",
+        "enabled": true,
+        "id": "aaaa166533fd49f3b11b1cdce2430000",
+        "name": "#{tenant}"
+      }
+    },
+    "serviceCatalog": [
+      {
+        "endpoints": [
+          {
+            "adminURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44",
+            "region": "RegionOne",
+            "internalURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44",
+            "id": "1a66e6af97c440b2a7bbc4f9735923d9",
+            "publicURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "compute",
+        "name": "nova"
+      },
+      {
+        "endpoints": [
+          {
+            "adminURL": "http://neutron-endpoint.example.com:9696/",
+            "region": "RegionOne",
+            "internalURL": "http://neutron-endpoint.example.com:9696/",
+            "id": "0418104da877468ca65d739142fa3454",
+            "publicURL": "http://neutron-endpoint.example.com:9696/"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "network",
+        "name": "neutron"
+      },
+      {
+        "endpoints": [
+          {
+            "adminURL": "http://glance-endpoint.example.com:9292",
+            "region": "RegionOne",
+            "internalURL": "http://glance-endpoint.example.com:9292",
+            "id": "246f33509ff64802b86eb081307ecec0",
+            "publicURL": "http://glance-endpoint.example.com:9292"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "image",
+        "name": "glance"
+      },
+      {
+        "endpoints": [
+          {
+            "adminURL": "#{auth_url}/v2.0",
+            "region": "RegionOne",
+            "internalURL": "http://endpoint.example.com:5000/v2.0",
+            "id": "2b982236cc084128bf42b647c1b7fb49",
+            "publicURL": "http://endpoint.example.com:5000/v2.0"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "identity",
+        "name": "keystone"
+      }
+    ],
+    "user": {
+      "username": "#{username}",
+      "roles_links": [],
+      "id": "a9994b2dee82423da7da572397d3157a",
+      "roles": [
+        {
+          "name": "admin"
+        }
+      ],
+      "name": "#{username}"
+    },
+    "metadata": {
+      "is_admin": 0,
+      "roles": [
+        "ce5330c512cc4bd289b3a725ad1106b7"
+      ]
+    }
+  }
+}
+    JSON
+  end
+end

--- a/test/yao/test_auth.rb
+++ b/test/yao/test_auth.rb
@@ -1,107 +1,16 @@
 class TestAuth < Test::Unit::TestCase
-
-  AUTH_JSON = \
-    "{\"auth\":{\"passwordCredentials\":{\"username\":\"udzura\",\"password\":\"XXXXXXXX\"},\"tenantName\":\"example\"}}"
-
-  RESPONSE_JSON = <<-JSON
-{
-  "access": {
-    "token": {
-      "issued_at": "2015-08-31T03:58:36.073232",
-      "expires": "2015-09-01T03:58:36Z",
-      "id": "aaaa166533fd49f3b11b1cdce2430000",
-      "tenant": {
-        "description": "Testing",
-        "enabled": true,
-        "id": "aaaa166533fd49f3b11b1cdce2430000",
-        "name": "example"
-      }
-    },
-    "serviceCatalog": [
-      {
-        "endpoints": [
-          {
-            "adminURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44",
-            "region": "RegionOne",
-            "internalURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44",
-            "id": "1a66e6af97c440b2a7bbc4f9735923d9",
-            "publicURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44"
-          }
-        ],
-        "endpoints_links": [],
-        "type": "compute",
-        "name": "nova"
-      },
-      {
-        "endpoints": [
-          {
-            "adminURL": "http://neutron-endpoint.example.com:9696/",
-            "region": "RegionOne",
-            "internalURL": "http://neutron-endpoint.example.com:9696/",
-            "id": "0418104da877468ca65d739142fa3454",
-            "publicURL": "http://neutron-endpoint.example.com:9696/"
-          }
-        ],
-        "endpoints_links": [],
-        "type": "network",
-        "name": "neutron"
-      },
-      {
-        "endpoints": [
-          {
-            "adminURL": "http://glance-endpoint.example.com:9292",
-            "region": "RegionOne",
-            "internalURL": "http://glance-endpoint.example.com:9292",
-            "id": "246f33509ff64802b86eb081307ecec0",
-            "publicURL": "http://glance-endpoint.example.com:9292"
-          }
-        ],
-        "endpoints_links": [],
-        "type": "image",
-        "name": "glance"
-      },
-      {
-        "endpoints": [
-          {
-            "adminURL": "http://endpoint.example.com:12345/v2.0",
-            "region": "RegionOne",
-            "internalURL": "http://endpoint.example.com:5000/v2.0",
-            "id": "2b982236cc084128bf42b647c1b7fb49",
-            "publicURL": "http://endpoint.example.com:5000/v2.0"
-          }
-        ],
-        "endpoints_links": [],
-        "type": "identity",
-        "name": "keystone"
-      }
-    ],
-    "user": {
-      "username": "udzura",
-      "roles_links": [],
-      "id": "a9994b2dee82423da7da572397d3157a",
-      "roles": [
-        {
-          "name": "admin"
-        }
-      ],
-      "name": "udzura"
-    },
-    "metadata": {
-      "is_admin": 0,
-      "roles": [
-        "ce5330c512cc4bd289b3a725ad1106b7"
-      ]
-    }
-  }
-}
-  JSON
+  include AuthStub
 
   def setup
-    stub_request(:post, "http://endpoint.example.com:12345/v2.0/tokens").with(body: AUTH_JSON)
-      .to_return(:status => 200, :body => RESPONSE_JSON, :headers => {'Content-Type' => 'application/json'})
+    @auth_url = "http://endpoint.example.com:12345"
+    username = "udzura"
+    tenant   = "example"
+    password = "XXXXXXXX"
 
-    Yao.config.set :auth_url, "http://endpoint.example.com:12345"
-    @token = Yao::Auth.new(tenant_name: "example", username: "udzura", password: "XXXXXXXX")
+    stub_auth_request(@auth_url, username, password, tenant)
+
+    Yao.config.set :auth_url, @auth_url
+    @token = Yao::Auth.new(tenant_name: tenant, username: username, password: password)
   end
 
   def teardown
@@ -132,8 +41,7 @@ class TestAuth < Test::Unit::TestCase
 
   def test_token_is_valid
     assert { @token.token == "aaaa166533fd49f3b11b1cdce2430000" }
-    assert { @token.issued_at == Time.parse("2015-08-31T03:58:36.073232") }
-    assert { @token.expire_at == Time.parse("2015-09-01T03:58:36Z") }
+    assert { @token.expire_at - @token.issued_at == 3600 }
     assert { @token.endpoints.size == 4 }
   end
 

--- a/test/yao/test_client.rb
+++ b/test/yao/test_client.rb
@@ -11,6 +11,7 @@ class TestClient < Test::Unit::TestCase
     handlers = [
       Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
+      Faraday::Request::GetOnly,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
       Faraday::Adapter::NetHttp
@@ -24,6 +25,7 @@ class TestClient < Test::Unit::TestCase
       Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
       Faraday::Request::OSToken,
+      Faraday::Request::GetOnly,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
       Faraday::Adapter::NetHttp
@@ -38,6 +40,7 @@ class TestClient < Test::Unit::TestCase
     handlers = [
       Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
+      Faraday::Request::GetOnly,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
       Faraday::Response::Logger,

--- a/test/yao/test_client.rb
+++ b/test/yao/test_client.rb
@@ -11,7 +11,7 @@ class TestClient < Test::Unit::TestCase
     handlers = [
       Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
-      Faraday::Request::GetOnly,
+      Faraday::Request::ReadOnly,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
       Faraday::Adapter::NetHttp
@@ -25,7 +25,7 @@ class TestClient < Test::Unit::TestCase
       Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
       Faraday::Request::OSToken,
-      Faraday::Request::GetOnly,
+      Faraday::Request::ReadOnly,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
       Faraday::Adapter::NetHttp
@@ -40,7 +40,7 @@ class TestClient < Test::Unit::TestCase
     handlers = [
       Faraday::Request::Accept,
       Faraday::Request::UrlEncoded,
-      Faraday::Request::GetOnly,
+      Faraday::Request::ReadOnly,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
       Faraday::Response::Logger,

--- a/test/yao/test_read_only.rb
+++ b/test/yao/test_read_only.rb
@@ -32,7 +32,7 @@ class TestOnly < Test::Unit::TestCase
   end
 
   def test_read_only!
-    assert_raise Yao::GetOnlyViolationError do
+    assert_raise Yao::ReadOnlyViolationError do
       Yao.read_only! do
         Yao::User.get_by_name(@username)
         Yao::User.create(name: "foo", email: "bar", password: "baz")

--- a/test/yao/test_read_only.rb
+++ b/test/yao/test_read_only.rb
@@ -88,5 +88,27 @@ class TestOnly < Test::Unit::TestCase
 
       assert_true Yao.config.raise_on_write
     end
+
+    Yao.read_only! do
+      assert_true Yao.config.raise_on_write
+
+      Yao.read_only do
+        assert_true  Yao.config.noop_on_write
+        assert_false Yao.config.raise_on_write
+      end
+
+      assert_true Yao.config.raise_on_write
+    end
+
+    Yao.read_only do
+      assert_true Yao.config.noop_on_write
+
+      Yao.read_only! do
+        assert_true  Yao.config.raise_on_write
+        assert_false Yao.config.noop_on_write
+      end
+
+      assert_true Yao.config.noop_on_write
+    end
   end
 end

--- a/test/yao/test_read_only.rb
+++ b/test/yao/test_read_only.rb
@@ -67,4 +67,26 @@ class TestOnly < Test::Unit::TestCase
     assert_false Yao.config.noop_on_write
     assert_false Yao.config.raise_on_write
   end
+
+  def test_reentrant_condition
+    Yao.read_only do
+      assert_true Yao.config.noop_on_write
+
+      Yao.read_only do
+        assert_true Yao.config.noop_on_write
+      end
+
+      assert_true Yao.config.noop_on_write
+    end
+
+    Yao.read_only! do
+      assert_true Yao.config.raise_on_write
+
+      Yao.read_only! do
+        assert_true Yao.config.raise_on_write
+      end
+
+      assert_true Yao.config.raise_on_write
+    end
+  end
 end

--- a/test/yao/test_read_only.rb
+++ b/test/yao/test_read_only.rb
@@ -1,123 +1,29 @@
 class TestOnly < Test::Unit::TestCase
-
-  AUTH_JSON = \
-    "{\"auth\":{\"passwordCredentials\":{\"username\":\"udzura\",\"password\":\"XXXXXXXX\"},\"tenantName\":\"example\"}}"
-
-  RESPONSE_JSON = <<-JSON
-{
-  "access": {
-    "token": {
-      "issued_at": "2015-08-31T03:58:36.073232",
-      "expires": "2015-09-01T03:58:36Z",
-      "id": "aaaa166533fd49f3b11b1cdce2430000",
-      "tenant": {
-        "description": "Testing",
-        "enabled": true,
-        "id": "aaaa166533fd49f3b11b1cdce2430000",
-        "name": "example"
-      }
-    },
-    "serviceCatalog": [
-      {
-        "endpoints": [
-          {
-            "adminURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44",
-            "region": "RegionOne",
-            "internalURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44",
-            "id": "1a66e6af97c440b2a7bbc4f9735923d9",
-            "publicURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44"
-          }
-        ],
-        "endpoints_links": [],
-        "type": "compute",
-        "name": "nova"
-      },
-      {
-        "endpoints": [
-          {
-            "adminURL": "http://neutron-endpoint.example.com:9696/",
-            "region": "RegionOne",
-            "internalURL": "http://neutron-endpoint.example.com:9696/",
-            "id": "0418104da877468ca65d739142fa3454",
-            "publicURL": "http://neutron-endpoint.example.com:9696/"
-          }
-        ],
-        "endpoints_links": [],
-        "type": "network",
-        "name": "neutron"
-      },
-      {
-        "endpoints": [
-          {
-            "adminURL": "http://glance-endpoint.example.com:9292",
-            "region": "RegionOne",
-            "internalURL": "http://glance-endpoint.example.com:9292",
-            "id": "246f33509ff64802b86eb081307ecec0",
-            "publicURL": "http://glance-endpoint.example.com:9292"
-          }
-        ],
-        "endpoints_links": [],
-        "type": "image",
-        "name": "glance"
-      },
-      {
-        "endpoints": [
-          {
-            "adminURL": "http://endpoint.example.com:12345/v2.0",
-            "region": "RegionOne",
-            "internalURL": "http://endpoint.example.com:5000/v2.0",
-            "id": "2b982236cc084128bf42b647c1b7fb49",
-            "publicURL": "http://endpoint.example.com:5000/v2.0"
-          }
-        ],
-        "endpoints_links": [],
-        "type": "identity",
-        "name": "keystone"
-      }
-    ],
-    "user": {
-      "username": "udzura",
-      "roles_links": [],
-      "id": "a9994b2dee82423da7da572397d3157a",
-      "roles": [
-        {
-          "name": "admin"
-        }
-      ],
-      "name": "udzura"
-    },
-    "metadata": {
-      "is_admin": 0,
-      "roles": [
-        "ce5330c512cc4bd289b3a725ad1106b7"
-      ]
-    }
-  }
-}
-  JSON
+  include AuthStub
 
   def setup
     auth_url = "http://endpoint.example.com:12345"
-    name = "udzura"
+    username = "udzura"
+    tenant   = "example"
+    password = "XXXXXXXX"
 
-    stub_request(:post, "#{auth_url}/v2.0/tokens").with(body: AUTH_JSON)
-      .to_return(:status => 200, :body => RESPONSE_JSON, :headers => {'Content-Type' => 'application/json'})
+    stub_auth_request(auth_url, username, password, tenant)
 
     Yao.configure do
-      auth_url auth_url
-      username name
-      tenant_name "example"
-      password "XXXXXXXX"
+      auth_url    auth_url
+      username    username
+      tenant_name tenant
+      password    password
     end
 
-    @name = name
-    @get_stub  = stub_request(:get,  "#{auth_url}/v2.0/users?name=#{name}")
+    @username = username
+    @get_stub  = stub_request(:get,  "#{auth_url}/v2.0/users?name=#{username}")
     @post_stub = stub_request(:post, "#{auth_url}/v2.0/users")
   end
 
   def test_read_only
     Yao.read_only do
-      Yao::User.get_by_name(@name)
+      Yao::User.get_by_name(@username)
       Yao::User.create(name: "foo", email: "bar", password: "baz")
     end
 
@@ -128,7 +34,7 @@ class TestOnly < Test::Unit::TestCase
   def test_read_only!
     assert_raise Yao::GetOnlyViolationError do
       Yao.read_only! do
-        Yao::User.get_by_name(@name)
+        Yao::User.get_by_name(@username)
         Yao::User.create(name: "foo", email: "bar", password: "baz")
       end
     end

--- a/test/yao/test_read_only.rb
+++ b/test/yao/test_read_only.rb
@@ -1,0 +1,139 @@
+class TestOnly < Test::Unit::TestCase
+
+  AUTH_JSON = \
+    "{\"auth\":{\"passwordCredentials\":{\"username\":\"udzura\",\"password\":\"XXXXXXXX\"},\"tenantName\":\"example\"}}"
+
+  RESPONSE_JSON = <<-JSON
+{
+  "access": {
+    "token": {
+      "issued_at": "2015-08-31T03:58:36.073232",
+      "expires": "2015-09-01T03:58:36Z",
+      "id": "aaaa166533fd49f3b11b1cdce2430000",
+      "tenant": {
+        "description": "Testing",
+        "enabled": true,
+        "id": "aaaa166533fd49f3b11b1cdce2430000",
+        "name": "example"
+      }
+    },
+    "serviceCatalog": [
+      {
+        "endpoints": [
+          {
+            "adminURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44",
+            "region": "RegionOne",
+            "internalURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44",
+            "id": "1a66e6af97c440b2a7bbc4f9735923d9",
+            "publicURL": "http://nova-endpoint.example.com:8774/v2/b598bf98671c47e1b955f8c9660e3c44"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "compute",
+        "name": "nova"
+      },
+      {
+        "endpoints": [
+          {
+            "adminURL": "http://neutron-endpoint.example.com:9696/",
+            "region": "RegionOne",
+            "internalURL": "http://neutron-endpoint.example.com:9696/",
+            "id": "0418104da877468ca65d739142fa3454",
+            "publicURL": "http://neutron-endpoint.example.com:9696/"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "network",
+        "name": "neutron"
+      },
+      {
+        "endpoints": [
+          {
+            "adminURL": "http://glance-endpoint.example.com:9292",
+            "region": "RegionOne",
+            "internalURL": "http://glance-endpoint.example.com:9292",
+            "id": "246f33509ff64802b86eb081307ecec0",
+            "publicURL": "http://glance-endpoint.example.com:9292"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "image",
+        "name": "glance"
+      },
+      {
+        "endpoints": [
+          {
+            "adminURL": "http://endpoint.example.com:12345/v2.0",
+            "region": "RegionOne",
+            "internalURL": "http://endpoint.example.com:5000/v2.0",
+            "id": "2b982236cc084128bf42b647c1b7fb49",
+            "publicURL": "http://endpoint.example.com:5000/v2.0"
+          }
+        ],
+        "endpoints_links": [],
+        "type": "identity",
+        "name": "keystone"
+      }
+    ],
+    "user": {
+      "username": "udzura",
+      "roles_links": [],
+      "id": "a9994b2dee82423da7da572397d3157a",
+      "roles": [
+        {
+          "name": "admin"
+        }
+      ],
+      "name": "udzura"
+    },
+    "metadata": {
+      "is_admin": 0,
+      "roles": [
+        "ce5330c512cc4bd289b3a725ad1106b7"
+      ]
+    }
+  }
+}
+  JSON
+
+  def setup
+    auth_url = "http://endpoint.example.com:12345"
+    name = "udzura"
+
+    stub_request(:post, "#{auth_url}/v2.0/tokens").with(body: AUTH_JSON)
+      .to_return(:status => 200, :body => RESPONSE_JSON, :headers => {'Content-Type' => 'application/json'})
+
+    Yao.configure do
+      auth_url auth_url
+      username name
+      tenant_name "example"
+      password "XXXXXXXX"
+    end
+
+    @name = name
+    @get_stub  = stub_request(:get,  "#{auth_url}/v2.0/users?name=#{name}")
+    @post_stub = stub_request(:post, "#{auth_url}/v2.0/users")
+  end
+
+  def test_read_only
+    Yao.read_only do
+      Yao::User.get_by_name(@name)
+      Yao::User.create(name: "foo", email: "bar", password: "baz")
+    end
+
+    assert_requested @get_stub
+    assert_not_requested @post_stub
+  end
+
+  def test_read_only!
+    assert_raise Yao::GetOnlyViolationError do
+      Yao.read_only! do
+        Yao::User.get_by_name(@name)
+        Yao::User.create(name: "foo", email: "bar", password: "baz")
+      end
+    end
+
+    assert_requested @get_stub
+    assert_not_requested @post_stub
+  end
+end

--- a/test/yao/test_read_only.rb
+++ b/test/yao/test_read_only.rb
@@ -42,4 +42,29 @@ class TestOnly < Test::Unit::TestCase
     assert_requested @get_stub
     assert_not_requested @post_stub
   end
+
+  def test_read_only_flags_life_cycle
+    assert_false Yao.config.noop_on_write
+    assert_false Yao.config.raise_on_write
+
+    assert_raise RuntimeError do
+      Yao.read_only do
+        assert_true Yao.config.noop_on_write
+        raise
+      end
+    end
+
+    assert_false Yao.config.noop_on_write
+    assert_false Yao.config.raise_on_write
+
+    assert_raise RuntimeError do
+      Yao.read_only! do
+        assert_true Yao.config.raise_on_write
+        raise
+      end
+    end
+
+    assert_false Yao.config.noop_on_write
+    assert_false Yao.config.raise_on_write
+  end
 end

--- a/test/yao/test_token.rb
+++ b/test/yao/test_token.rb
@@ -24,30 +24,6 @@ class TestToken < Test::Unit::TestCase
     assert { ! t.expired? }
   end
 
-  AUTH_JSON = \
-    "{\"auth\":{\"passwordCredentials\":{\"username\":\"udzura\",\"password\":\"XXXXXXXX\"},\"tenantName\":\"example\"}}"
-
-  def gen_response_json
-    <<-JSON
-{
-  "access": {
-    "token": {
-      "issued_at": "#{Time.now.iso8601}",
-      "expires": "#{(Time.now + 3600).utc.iso8601}",
-      "id": "aaaa166533fd49f3b11b1cdce2430000",
-      "tenant": {
-        "description": "Testing",
-        "enabled": true,
-        "id": "aaaa166533fd49f3b11b1cdce2430000",
-        "name": "example"
-      }
-    },
-    "serviceCatalog": []
-  }
-}
-    JSON
-  end
-
   def test_reflesh
     auth_url = "http://endpoint.example.com:12345"
     username = "udzura"

--- a/test/yao/test_token.rb
+++ b/test/yao/test_token.rb
@@ -1,4 +1,6 @@
 class TestToken < Test::Unit::TestCase
+  include AuthStub
+
   def setup
     stub(Yao.config).debug { false }
     stub(Yao.config).debug_record_response { false }
@@ -47,12 +49,17 @@ class TestToken < Test::Unit::TestCase
   end
 
   def test_reflesh
+    auth_url = "http://endpoint.example.com:12345"
+    username = "udzura"
+    tenant   = "example"
+    password = "XXXXXXXX"
+
     auth_info = {
       auth: {
         passwordCredentials: {
-          username: "udzura", password: "XXXXXXXX"
+          username: username, password: password
         },
-        tenantName: "example"
+        tenantName: tenant
       }
     }
     t = Yao::Token.new(auth_info)
@@ -63,10 +70,9 @@ class TestToken < Test::Unit::TestCase
       })
     assert { t.token == "old_token" }
 
-    stub_request(:post, "http://endpoint.example.com:12345/v2.0/tokens").with(body: AUTH_JSON)
-      .to_return(:status => 200, :body => gen_response_json, :headers => {'Content-Type' => 'application/json'})
+    stub_auth_request(auth_url, username, password, tenant)
 
-    Yao.config.auth_url "http://endpoint.example.com:12345"
+    Yao.config.auth_url auth_url
     t.reflesh(Yao.default_client.default)
 
     assert { t.token == "aaaa166533fd49f3b11b1cdce2430000" }


### PR DESCRIPTION
This implements two methods `Yao.read_only` and `Yao.read_only!` as I proposed at https://github.com/yaocloud/yao/issues/27.

I'm worried about the way to detect whether it is inside `read_only`, `read_only!` or else is not thread safe. Because it modifies and refers global setting `Yao.config`.