### PR TITLE
Fix network service endpoint handling

### DIFF
--- a/lib/yao/client.rb
+++ b/lib/yao/client.rb
@@ -27,7 +27,8 @@ module Yao
           # XXX: neutron just have v2.0 API and endpoint may not have version prefix
           if type == "network"
             urls = urls.map {|public_or_admin, url|
-              url = URI.parse(url).path == "/" ? File.join(url, "v2.0") : url
+              path = URI.parse(url).path
+              url = (path == '' || path == '/') ? File.join(url, "v2.0") : url
               [public_or_admin, url]
             }.to_h
           end


### PR DESCRIPTION
Some provider gives an endpoint URL without a trailing slash for the neutron API, in which case `URI.parse(url).path` is the empty string.

example:
```ruby
     {"endpoints"=>
       [{"region"=>"tyo1", "publicURL"=>"https://networking.tyo1.conoha.io"}],
      "endpoints_links"=>[],
      "type"=>"network",
      "name"=>"Network Service"},
```