### PR TITLE
Raise when specified API is not available in the service catalog

### DIFF
--- a/lib/yao/client.rb
+++ b/lib/yao/client.rb
@@ -32,8 +32,8 @@ module Yao
             }.to_h
           end
 
-          self.pool[type]       = Yao::Client.gen_client(urls[:public_url], token: token)
-          self.admin_pool[type] = Yao::Client.gen_client(urls[:admin_url],  token: token)
+          self.pool[type]       = Yao::Client.gen_client(urls[:public_url], token: token) if urls[:public_url]
+          self.admin_pool[type] = Yao::Client.gen_client(urls[:admin_url],  token: token) if urls[:admin_url]
         end
       end
     end

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -51,7 +51,7 @@ module Yao::Resources
         Yao.default_client.admin_pool[service]
       else
         Yao.default_client.pool[service]
-      end
+      end or raise "You do not have #{@admin ? 'admin' : 'public'} access to the #{service} service"
     end
 
     def as_member(&blk)


### PR DESCRIPTION
When you call an admin API and the admin API is not available for the current user, Faraday tries to fetch a resource from a URI like `http://tenants`. It's hard to understand what is happening.
This patch makes the REST client to raise more friendly exception in such a condition.