### PR TITLE
Fix warnings

### DIFF
--- a/lib/yao/auth.rb
+++ b/lib/yao/auth.rb
@@ -1,4 +1,3 @@
-require 'yao'
 require 'json'
 require 'time'
 

--- a/lib/yao/client.rb
+++ b/lib/yao/client.rb
@@ -1,4 +1,3 @@
-require 'yao'
 require 'yao/config'
 require 'faraday'
 require 'yao/plugins/default_client_generator'

--- a/lib/yao/config.rb
+++ b/lib/yao/config.rb
@@ -78,6 +78,6 @@ module Yao
   end
 
   def self.configure(&blk)
-    config &blk
+    config(&blk)
   end
 end

--- a/lib/yao/config.rb
+++ b/lib/yao/config.rb
@@ -1,5 +1,3 @@
-require 'yao'
-
 module Yao
   class Config
     def _configuration_defaults


### PR DESCRIPTION
This patch deals with compiler warnings that `require 'yao'` emits in Ruby 2.3.0.