### PR TITLE
Become something useful to hold the tenant ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ mkmf.log
 tmp
 
 /vendor/
+
+/bin/

--- a/lib/yao/token.rb
+++ b/lib/yao/token.rb
@@ -21,6 +21,7 @@ module Yao
       @token = token_data["id"]
       @issued_at = Time.parse(token_data["issued_at"]).localtime
       @expire_at = Time.parse(token_data["expires"]).localtime
+      Yao.current_tenant_id token_data["tenant"]["id"]
     end
 
     def expired?
@@ -35,7 +36,6 @@ module Yao
         req.body = auth_info.to_json
         req.headers['Content-Type'] = 'application/json'
       end
-
       body = res.body["access"]
 
       register(body["token"])
@@ -58,5 +58,12 @@ module Yao
 
       Yao.default_client.register_endpoints(@endpoints, token: self)
     end
+  end
+
+  def self.current_tenant_id(id=nil)
+    if id
+      @__tenant_id = id
+    end
+    @__tenant_id
   end
 end

--- a/test/yao/test_token.rb
+++ b/test/yao/test_token.rb
@@ -11,7 +11,10 @@ class TestToken < Test::Unit::TestCase
     t.register({
         "id" => "aaaa166533fd49f3b11b1cdce2430000",
         "issued_at" => Time.now.iso8601,
-        "expires" => (Time.now - 3600).utc.iso8601
+        "expires" => (Time.now - 3600).utc.iso8601,
+        "tenant" => {
+          "id" => "aaaa166533fd49f3b11b1cdce2430000"
+        }
       })
 
     assert { t.expired? }
@@ -19,7 +22,10 @@ class TestToken < Test::Unit::TestCase
     t.register({
         "id" => "aaaa166533fd49f3b11b1cdce2430000",
         "issued_at" => Time.now.iso8601,
-        "expires" => (Time.now + 3600).utc.iso8601
+        "expires" => (Time.now + 3600).utc.iso8601,
+        "tenant" => {
+          "id" => "aaaa166533fd49f3b11b1cdce2430000"
+        }
       })
     assert { ! t.expired? }
   end
@@ -42,7 +48,10 @@ class TestToken < Test::Unit::TestCase
     t.register({
         "id" => "old_token",
         "issued_at" => Time.now.iso8601,
-        "expires" => (Time.now - 3600).utc.iso8601
+        "expires" => (Time.now - 3600).utc.iso8601,
+        "tenant" => {
+          "id" => "aaaa166533fd49f3b11b1cdce2430000"
+        }
       })
     assert { t.token == "old_token" }
 
@@ -52,5 +61,19 @@ class TestToken < Test::Unit::TestCase
     t.reflesh(Yao.default_client.default)
 
     assert { t.token == "aaaa166533fd49f3b11b1cdce2430000" }
+  end
+
+  def test_current_tenant_id
+    t = Yao::Token.new({})
+    t.register({
+        "id" => "aaaa166533fd49f3b11b1cdce2430000",
+        "issued_at" => Time.now.iso8601,
+        "expires" => (Time.now - 3600).utc.iso8601,
+        "tenant" => {
+          "id" => "aaaa166533fd49f3b11b1cdce2430000"
+        }
+      })
+
+    assert { Yao.current_tenant_id == "aaaa166533fd49f3b11b1cdce2430000" }
   end
 end


### PR DESCRIPTION
hi! Yatteru?
get a list of tenant ID is required admin privileges.
but, liist If you save the tenant ID is not required.

japanese.
ログイン時にテナントIDを保持しておくと、管理者権限が必要なテナントリスト取得が不要になるので、多くのオペレーションがメンバー権限で出来るようになります。