### PR TITLE
Add yao/setup to initialize Yao from environment variables

### DIFF
--- a/lib/yao/setup.rb
+++ b/lib/yao/setup.rb
@@ -1,0 +1,8 @@
+require 'yao'
+
+Yao.config do
+  auth_url    ENV['OS_AUTH_URL']
+  tenant_name ENV['OS_TENANT_NAME']
+  username    ENV['OS_USERNAME']
+  password    ENV['OS_PASSWORD']
+end


### PR DESCRIPTION
`irb -ryao/setup` will give you an IRB console with Yao ready if you have standard `OS_**` environment variables (use direnv or whatever you like to export them)