### PR TITLE
任意のエンドポイントを利用可能にします

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Yao::Network.list # list up networks...
 Yao::Server.list_detail # list up instances...
 ```
 
+If you want to override some of endpoints by service, you can do:
+
+```ruby
+Yao.configure do
+  auth_url    "http://endpoint.example.com:12345"
+  tenant_name "example"
+  username    "udzura"
+  password    "XXXXXXXX"
+  endpoints   identity: { public: "http://override-endpoint.example.com:35357/v3.0" }
+end
+```
+
 ## Support policy
 
 YAO supports rubies which are supported by Ruby Core Team. Please look into [`.travis.yml`](./.travis.yml) 's directive.

--- a/lib/yao/client.rb
+++ b/lib/yao/client.rb
@@ -3,6 +3,8 @@ require 'faraday'
 require 'yao/plugins/default_client_generator'
 
 module Yao
+  Yao.config.param :endpoints, nil
+
   module Client
     class ClientSet
       def initialize
@@ -32,8 +34,11 @@ module Yao
             }.to_h
           end
 
-          self.pool[type]       = Yao::Client.gen_client(urls[:public_url], token: token) if urls[:public_url]
-          self.admin_pool[type] = Yao::Client.gen_client(urls[:admin_url],  token: token) if urls[:admin_url]
+          force_public_url = Yao.config.endpoints[type.to_sym][:public] rescue nil
+          force_admin_url = Yao.config.endpoints[type.to_sym][:admin] rescue nil
+
+          self.pool[type] = Yao::Client.gen_client(force_public_url || urls[:public_url], token: token) if force_public_url || urls[:public_url]
+          self.admin_pool[type] = Yao::Client.gen_client(force_admin_url || urls[:admin_url],  token: token) if force_admin_url || urls[:admin_url]
         end
       end
     end

--- a/test/yao/test_auth.rb
+++ b/test/yao/test_auth.rb
@@ -14,6 +14,9 @@ class TestAuth < Test::Unit::TestCase
   end
 
   def teardown
+    Yao.configure do
+      endpoints nil
+    end
   end
 
   def test_auth_successful
@@ -57,4 +60,17 @@ class TestAuth < Test::Unit::TestCase
     end
     assert_received(auth) {|a| a.new }
   end
+
+  def test_override_endpoint
+    Yao.configure do
+      auth_url    "http://endpoint.example.com:12345"
+      tenant_name "example"
+      username    "udzura"
+      password    "XXXXXXXX"
+      endpoints ({ identity: { public: "http://override-endpoint.example.com:35357/v3.0" } })
+    end
+    assert(Yao.default_client.pool["identity"].url_prefix.to_s, "http://override-endpoint.example.com:35357/v3.0")
+  end
+
+
 end

--- a/test/yao/test_config.rb
+++ b/test/yao/test_config.rb
@@ -56,7 +56,7 @@ class TestConfig < Test::Unit::TestCase
     mock(auth).try_new.times(count)
     Yao::Config::HOOK_RENEW_CLIENT_KEYS.each do |key|
       Yao.configure do
-        set key, "dummy"
+        set key, "http://dummy"
       end
     end
 

--- a/yao.gemspec
+++ b/yao.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "json"
-  spec.add_dependency "faraday"
+  spec.add_dependency "faraday", "~> 0.12.0"
   spec.add_dependency "faraday_middleware"
 
   spec.add_development_dependency "bundler", ">= 1.10"


### PR DESCRIPTION
apiエンドポイントのバージョンアップ時の互換性保持などの用途で、クライアントサイドで任意のエンドポイントに上書きしてアクセスできるようにします。