### PR TITLE
add role assignment

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -18,6 +18,7 @@ module Yao
     autoload :Host,              "yao/resources/host"
     autoload :User,              "yao/resources/user"
     autoload :Role,              "yao/resources/role"
+    autoload :RoleAssignment,    "yao/resources/role_assignment"
 
     autoload :Resource,          "yao/resources/resource"
     autoload :Meter,             "yao/resources/meter"

--- a/lib/yao/resources/role_assignment.rb
+++ b/lib/yao/resources/role_assignment.rb
@@ -1,0 +1,17 @@
+module Yao::Resources
+  class RoleAssignment < Base
+    friendly_attributes :scope, :role, :user
+    self.service        = "identity"
+    self.resource_name  = "role_assignment"
+    self.resources_name  = "role_assignments"
+    self.admin          = true
+    self.api_version    = "v3"
+
+    def project
+      @project ||= Yao::Tenant.get(scope["project"]["id"])
+    end
+
+    map_attribute_to_resource  :role => Role
+    map_attribute_to_resource  :user => User
+  end
+end


### PR DESCRIPTION
kanameを高速化するための、どのユーザーがどのテナントでどのロールに所属しているかという一覧を取得できるようにしました。keystoneのv3から利用可能なため、api versionを指定しています。