### PR TITLE
refresh token endpoint should be equal to initial

### DIFF
--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -22,7 +22,7 @@ class Faraday::Request::OSToken
 
   def call(env)
     if @token.expired?
-      @token.reflesh(Yao.default_client.default)
+      @token.refresh(Yao.default_client.default)
     end
 
     env[:request_headers]['X-Auth-Token'] = @token.to_s

--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -51,7 +51,7 @@ class Faraday::Request::ReadOnly
   private
 
   ALLOWED_REQUESTS = [
-    {method: :post, path: "/v2.0/tokens"}
+    {method: :post, path: "/tokens"}
   ]
 
   def allowed_request?(env)

--- a/lib/yao/token.rb
+++ b/lib/yao/token.rb
@@ -4,7 +4,7 @@ module Yao
   class Token
     def self.issue(cli, auth_info)
       t = new(auth_info)
-      t.reflesh(cli)
+      t.refresh(cli)
       t
     end
 
@@ -29,7 +29,7 @@ module Yao
       Time.now >= self.expire_at
     end
 
-    def reflesh(cli)
+    def refresh(cli)
       @endpoints.clear
 
       res = cli.post("#{Yao.config.auth_url}/tokens") do |req|

--- a/lib/yao/token.rb
+++ b/lib/yao/token.rb
@@ -32,7 +32,7 @@ module Yao
     def reflesh(cli)
       @endpoints.clear
 
-      res = cli.post('/v2.0/tokens') do |req|
+      res = cli.post("#{Yao.config.auth_url}/tokens") do |req|
         req.body = auth_info.to_json
         req.headers['Content-Type'] = 'application/json'
       end

--- a/test/support/auth_stub.rb
+++ b/test/support/auth_stub.rb
@@ -1,6 +1,6 @@
 module AuthStub
   def stub_auth_request(auth_url, username, password, tenant)
-    stub_request(:post, "#{auth_url}/v2.0/tokens")
+    stub_request(:post, "#{auth_url}/tokens")
       .with(
         body: auth_json(username, password, tenant)
       ).to_return(
@@ -81,7 +81,7 @@ module AuthStub
       {
         "endpoints": [
           {
-            "adminURL": "#{auth_url}/v2.0",
+            "adminURL": "#{auth_url}",
             "region": "RegionOne",
             "internalURL": "http://endpoint.example.com:5000/v2.0",
             "id": "2b982236cc084128bf42b647c1b7fb49",

--- a/test/yao/test_auth.rb
+++ b/test/yao/test_auth.rb
@@ -2,7 +2,7 @@ class TestAuth < Test::Unit::TestCase
   include AuthStub
 
   def setup
-    @auth_url = "http://endpoint.example.com:12345"
+    @auth_url = "http://endpoint.example.com:12345/v2.0"
     username = "udzura"
     tenant   = "example"
     password = "XXXXXXXX"
@@ -21,7 +21,7 @@ class TestAuth < Test::Unit::TestCase
 
   def test_auth_successful
     cli = Yao.default_client.pool["default"]
-    assert { cli.url_prefix.to_s == "http://endpoint.example.com:12345/" }
+    assert { cli.url_prefix.to_s == "http://endpoint.example.com:12345/v2.0" }
   end
 
   def test_service_sclients_initialized
@@ -53,7 +53,7 @@ class TestAuth < Test::Unit::TestCase
     stub(auth).new
 
     Yao.configure do
-      auth_url    "http://endpoint.example.com:12345"
+      auth_url    "http://endpoint.example.com:12345/2.0"
       tenant_name "example"
       username    "udzura"
       password    "XXXXXXXX"
@@ -63,7 +63,7 @@ class TestAuth < Test::Unit::TestCase
 
   def test_override_endpoint
     Yao.configure do
-      auth_url    "http://endpoint.example.com:12345"
+      auth_url    "http://endpoint.example.com:12345/v2.0"
       tenant_name "example"
       username    "udzura"
       password    "XXXXXXXX"

--- a/test/yao/test_read_only.rb
+++ b/test/yao/test_read_only.rb
@@ -2,7 +2,7 @@ class TestOnly < Test::Unit::TestCase
   include AuthStub
 
   def setup
-    auth_url = "http://endpoint.example.com:12345"
+    auth_url = "http://endpoint.example.com:12345/v2.0"
     username = "udzura"
     tenant   = "example"
     password = "XXXXXXXX"
@@ -17,8 +17,8 @@ class TestOnly < Test::Unit::TestCase
     end
 
     @username = username
-    @get_stub  = stub_request(:get,  "#{auth_url}/v2.0/users?name=#{username}")
-    @post_stub = stub_request(:post, "#{auth_url}/v2.0/users")
+    @get_stub  = stub_request(:get,  "#{auth_url}/users?name=#{username}")
+    @post_stub = stub_request(:post, "#{auth_url}/users")
   end
 
   def test_read_only

--- a/test/yao/test_token.rb
+++ b/test/yao/test_token.rb
@@ -31,7 +31,7 @@ class TestToken < Test::Unit::TestCase
   end
 
   def test_reflesh
-    auth_url = "http://endpoint.example.com:12345"
+    auth_url = "http://endpoint.example.com:12345/v2.0"
     username = "udzura"
     tenant   = "example"
     password = "XXXXXXXX"

--- a/test/yao/test_token.rb
+++ b/test/yao/test_token.rb
@@ -30,7 +30,7 @@ class TestToken < Test::Unit::TestCase
     assert { ! t.expired? }
   end
 
-  def test_reflesh
+  def test_refresh
     auth_url = "http://endpoint.example.com:12345/v2.0"
     username = "udzura"
     tenant   = "example"
@@ -58,7 +58,7 @@ class TestToken < Test::Unit::TestCase
     stub_auth_request(auth_url, username, password, tenant)
 
     Yao.config.auth_url auth_url
-    t.reflesh(Yao.default_client.default)
+    t.refresh(Yao.default_client.default)
 
     assert { t.token == "aaaa166533fd49f3b11b1cdce2430000" }
   end


### PR DESCRIPTION
refresh endpoint differ from initial when auth_url have some paths.

ex:

auth_url = "http://endpoint.example.com:12345/path/to/v2.0"

 * initial: http://endpoint.example.com:12345/path/to/v2.0/tokens
 * refresh: http://endpoint.example.com:12345/v2.0/tokens

both of them should be equal.