### PR TITLE
unify auth_url pointing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 require 'yao'
 
 Yao.configure do
-  auth_url    "http://keystone.example.local:8080/v2.0/tokens"
+  auth_url    "http://keystone.example.local:8080/v2.0"
   tenant_name "fooproject"
   username    "udzura"
   password    "tonk0tsu-r@men"
@@ -47,7 +47,7 @@ If you want to override some of endpoints by service, you can do:
 
 ```ruby
 Yao.configure do
-  auth_url    "http://endpoint.example.com:12345"
+  auth_url    "http://endpoint.example.com:12345/v2.0"
   tenant_name "example"
   username    "udzura"
   password    "XXXXXXXX"
@@ -70,7 +70,7 @@ You can use a prittier namespace:
 require 'yao/is_openstack_client'
 
 OpenStack.configure do
-  auth_url    "http://keystone.example.local:8080/v2.0/tokens"
+  auth_url    "http://keystone.example.local:8080/v2.0"
   tenant_name "fooproject"
   username    "udzura"
   password    "tonk0tsu-r@men"

--- a/test/yao/test_auth.rb
+++ b/test/yao/test_auth.rb
@@ -53,7 +53,7 @@ class TestAuth < Test::Unit::TestCase
     stub(auth).new
 
     Yao.configure do
-      auth_url    "http://endpoint.example.com:12345/2.0"
+      auth_url    "http://endpoint.example.com:12345/v2.0"
       tenant_name "example"
       username    "udzura"
       password    "XXXXXXXX"


### PR DESCRIPTION
fix https://github.com/yaocloud/yao/pull/59#discussion_r115909995 and README that auth_url end as api version number.