### PR TITLE
prevent for url_prefix reset. force set v3 api version.

### DIFF
--- a/lib/yao/resources/role_assignment.rb
+++ b/lib/yao/resources/role_assignment.rb
@@ -6,6 +6,7 @@ module Yao::Resources
     self.resources_name  = "role_assignments"
     self.admin          = true
     self.api_version    = "v3"
+    self.client.url_prefix = Yao.config.auth_url.gsub('v2.0', 'v3')
 
     def project
       @project ||= Yao::Tenant.get(scope["project"]["id"])


### PR DESCRIPTION
when I set `auth_url: "https://endpoint.example.com/path/to/v2.0/"`, url_prefix set to `https://endpoint.example.com/v3` and kaname occurs `Yao::ServerError` because of 302 happened.

it's prefer to reuse and replace only version number of auth_url path in role_assignment.