### PR TITLE
Move list_detail to server resource

### DIFF
--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -84,14 +84,6 @@ module Yao::Resources
       end
     end
 
-    def list_detail(query={})
-      return_resources(
-        resources_from_json(
-          GET([resources_path, "detail"].join("/"), query).body
-        )
-      )
-    end
-
     def get(id_or_permalink, query={})
       res = if id_or_permalink =~ /^https?:\/\//
               GET(id_or_permalink, query)

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -44,6 +44,14 @@ module Yao::Resources
 
     class << self
       alias :stop :shutoff
+
+      def list_detail(query={})
+        return_resources(
+          resources_from_json(
+            GET([resources_path, "detail"].join("/"), query).body
+          )
+        )
+      end
     end
 
     extend MetadataAvailable


### PR DESCRIPTION
Because `/detail` exists only in nova api.

nova https://developer.openstack.org/api-ref/compute/
neutron https://developer.openstack.org/api-ref/networking/v2/
glance https://developer.openstack.org/api-ref/image/v2/index.html

(It is also in cinder. but yao not support yet.)