### PR TITLE
Improve get method

### DIFF
--- a/lib/yao/error.rb
+++ b/lib/yao/error.rb
@@ -1,5 +1,6 @@
 module Yao
   class ReadOnlyViolationError < ::StandardError; end
+  class TooManyItemFonud       < ::StandardError; end
 
   class ServerError < ::StandardError
     def initialize(message, requested_env)

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -90,17 +90,9 @@ module Yao::Resources
             elsif uuid?(id_or_name_or_permalink)
               GET([resources_path, id_or_name_or_permalink].join("/"), query)
             else
-              # At first, search by ID. If nothing is found, search by name.
-              begin
-                GET([resources_path, id_or_name_or_permalink].join("/"), query)
-              rescue Yao::ItemNotFound
-                item = find_by_name(id_or_name_or_permalink)
-                if item.size > 1
-                  raise "More than one resource exists with the name '#{id_or_name_or_permalink}'"
-                end
-                GET([resources_path, item.first.id].join("/"), query)
-              end
+              get_by_name(id_or_name_or_permalink, query)
             end
+
       return_resource(resource_from_json(res.body))
     end
     alias find get
@@ -160,6 +152,19 @@ module Yao::Resources
 
     def uuid?(str)
       /^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$/ === str
+    end
+
+    def get_by_name(name, query={})
+      # At first, search by ID. If nothing is found, search by name.
+      begin
+        GET([resources_path, name].join("/"), query)
+      rescue Yao::ItemNotFound
+        item = find_by_name(name)
+        if item.size > 1
+          raise "More than one resource exists with the name '#{name}'"
+        end
+        GET([resources_path, item.first.id].join("/"), query)
+      end
     end
   end
 end

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -86,7 +86,7 @@ module Yao::Resources
 
     def get(id_or_name_or_permalink, query={})
       res = if id_or_name_or_permalink =~ /^https?:\/\//
-              GET(id_or_permalink, query)
+              GET(id_or_name_or_permalink, query)
             elsif uuid?(id_or_name_or_permalink)
               GET([resources_path, id_or_name_or_permalink].join("/"), query)
             else

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -85,7 +85,7 @@ module Yao::Resources
     end
 
     def get(id_or_name_or_permalink, query={})
-      res = if id_or_name_or_permalink.start_with?(/https?:\/\//)
+      res = if id_or_name_or_permalink.start_with?("http://", "https://")
               GET(id_or_name_or_permalink, query)
             elsif uuid?(id_or_name_or_permalink)
               GET([resources_path, id_or_name_or_permalink].join("/"), query)

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -161,7 +161,7 @@ module Yao::Resources
       rescue Yao::ItemNotFound
         item = find_by_name(name)
         if item.size > 1
-          raise "More than one resource exists with the name '#{name}'"
+          raise Yao::TooManyItemFonud.new("More than one resource exists with the name '#{name}'")
         end
         GET([resources_path, item.first.id].join("/"), query)
       end

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -90,7 +90,17 @@ module Yao::Resources
             elsif uuid?(id_or_name_or_permalink)
               GET([resources_path, id_or_name_or_permalink].join("/"), query)
             else
-              find_by_name(id_or_name_or_permalink, query)
+              # At first, search by ID. If nothing is found, search by name.
+              begin
+                GET([resources_path, id_or_name_or_permalink].join("/"), query)
+              rescue Yao::ItemNotFound
+                item = find_by_name(id_or_name_or_permalink)
+                p item
+                if item.size > 1
+                  raise "More than one resource exists with the name '#{id_or_name_or_permalink}'"
+                end
+                GET([resources_path, item.first.id].join("/"), query)
+              end
             end
       return_resource(resource_from_json(res.body))
     end

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -95,7 +95,6 @@ module Yao::Resources
                 GET([resources_path, id_or_name_or_permalink].join("/"), query)
               rescue Yao::ItemNotFound
                 item = find_by_name(id_or_name_or_permalink)
-                p item
                 if item.size > 1
                   raise "More than one resource exists with the name '#{id_or_name_or_permalink}'"
                 end

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -85,7 +85,7 @@ module Yao::Resources
     end
 
     def get(id_or_name_or_permalink, query={})
-      res = if id_or_name_or_permalink =~ /^https?:\/\//
+      res = if id_or_name_or_permalink.start_with?(/https?:\/\//)
               GET(id_or_name_or_permalink, query)
             elsif uuid?(id_or_name_or_permalink)
               GET([resources_path, id_or_name_or_permalink].join("/"), query)

--- a/test/config.rb
+++ b/test/config.rb
@@ -5,6 +5,7 @@ require 'yao'
 
 require 'support/auth_stub'
 require 'support/authv3_stub'
+require 'support/restfully_accesible_stub'
 
 require 'webmock/test_unit'
 

--- a/test/support/restfully_accesible_stub.rb
+++ b/test/support/restfully_accesible_stub.rb
@@ -1,0 +1,25 @@
+module RestfullAccessibleStub
+  def stub_get_request(url, resource_name)
+    stub_request(:get, url)
+      .with(
+        headers: request_headers
+      ).to_return(
+        status: 200,
+        body: %Q[{#{resource_name}: "dummy"}]
+      )
+  end
+
+  def stub_get_request_not_found(url)
+    stub_request(:get, url)
+      .with(
+        headers: request_headers
+      ).to_return(
+        status: 404,
+        body: "itemNotFound"
+      )
+  end
+
+  def request_headers
+    {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.12.2'}
+  end
+end

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -1,26 +1,69 @@
 class TestRestfullyAccesible < Test::Unit::TestCase
-  include Yao::Resources::RestfullyAccessible
+  include RestfullAccessibleStub
+  class Test
+    class << self
+      attr_accessor :client
+    end
+    extend Yao::Resources::RestfullyAccessible
+  end
 
-  def test_get
-    mock(self).find_by_name("dummy", {}) { Struct.new(:body).new("dummy") }
-    mock(self).resource_from_json("dummy") { "dummy" }
-    mock(self).return_resource("dummy") { "dummy" }
+  def setup
+    @url = "https://example.com:12345"
+    @resource_name  = "dummy_resource"
+    @resources_name = "dummy_resources"
 
-    get("dummy")
-    RR.verify
+    Test.resource_name  = @resource_name
+    Test.resources_name = @resources_name
+    Test.client = Yao::Client.gen_client(@url)
+  end
+
+  sub_test_case 'get' do
+    test 'permalink' do
+      stub_get_request("https://example.com/dummy_resource", @resource_name)
+      mock(Test).new("dummy_resource") { "OK" }
+      assert_equal(Test.get("https://example.com/dummy_resource"), "OK")
+    end
+
+    test 'uuid' do
+      uuid = "00112233-4455-6677-8899-aabbccddeeff"
+      stub_get_request([@url, @resources_name, uuid].join('/'), @resource_name)
+      mock(Test).new("dummy_resource") { "OK" }
+      assert_equal(Test.get(uuid), "OK")
+    end
+
+    test 'id (not uuid)' do
+      id = "1"
+      stub_get_request([@url, @resources_name, id].join('/'), @resource_name)
+      mock(Test).new("dummy_resource") { "OK" }
+      assert_equal(Test.get(id), "OK")
+    end
+
+    test 'name' do
+      Test.return_single_on_querying = true
+      name = "dummy"
+      uuid = "00112233-4455-6677-8899-aabbccddeeff"
+
+      stub_get_request_not_found([@url, @resources_name, name].join('/'))
+      stub_get_request([@url, "#{@resources_name}?name=dummy"].join('/'), @resources_name)
+      mock(Test).new("dummy_resource") { [Struct.new(:id).new(uuid)] }
+      stub_get_request([@url, @resources_name, uuid].join('/'), @resources_name)
+      mock(Test).new("dummy_resource") { "OK" }
+
+      assert_equal(Test.get(name), "OK")
+    end
   end
 
   def test_find_by_name
-    mock(self).list({"name" => "dummy"}) { "dummy" }
+    mock(Test).list({"name" => "dummy"}) { "dummy" }
 
-    assert_equal(find_by_name("dummy"), "dummy")
+    assert_equal(Test.find_by_name("dummy"), "dummy")
   end
 
   def test_uuid?
-    assert_equal(uuid?("00112233-4455-6677-8899-aabbccddeeff"), true)
+    assert_equal(Test.send(:uuid?, "00112233-4455-6677-8899-aabbccddeeff"), true)
 
     # not uuid
-    assert_equal(uuid?("dummy resource"), false)
-    assert_equal(uuid?("00112233445566778899aabbccddeeff"), false)
+    assert_equal(Test.send(:uuid?, "dummy resource"), false)
+    assert_equal(Test.send(:uuid?, "00112233445566778899aabbccddeeff"), false)
   end
 end


### PR DESCRIPTION
getメソッドにUUIDではないid(例えばflavorはUUIDである必要がない。以降id)を渡したときに、nameと解釈されてしまい、正しく処理されない問題があったため修正しました。

## 処理の順番について
find_by_nameにidを渡してしまうと、意図しないアイテムが返ってくることがある。
例えば、`id_or_name_or_permalink=1` の場合、`find_by_name`を通すと`example1`のようなリソースが返ってくる。

そのため、先にidがリソース内に存在しないかGETを行いItemNotFoundが返って来てからはじめてfind_by_name以降の処理に移るようにした。