### PR TITLE
Add methods to Yao::Resources::Hypervisor

### DIFF
--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -20,5 +20,16 @@ module Yao::Resources
     self.service        = "compute"
     self.resource_name  = "os-hypervisor"
     self.resources_name = "os-hypervisors"
+
+    class << self
+      def list_detail(query={})
+        return_resources(
+          resources_from_json(
+            GET([resources_path, "detail"].join("/"), query).body
+          )
+        )
+      end
+    end
+    
   end
 end

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Yao::Resources
   class Hypervisor < Base
     friendly_attributes :hypervisor_hostname, :hypervisor_type, :hypervisor_version, :running_vms, :current_workload,
@@ -29,7 +31,13 @@ module Yao::Resources
           )
         )
       end
+
+      def statistics
+        json = GET([resources_path, "statistics"].join("/")).body
+        Yao::Resources::Hypervisor::Statistics.new(json["hypervisor_statistics"])
+      end
     end
-    
+
+    class Statistics < OpenStruct; end
   end
 end

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -36,8 +36,16 @@ module Yao::Resources
         json = GET([resources_path, "statistics"].join("/")).body
         Yao::Resources::Hypervisor::Statistics.new(json["hypervisor_statistics"])
       end
+
+      def uptime(id)
+        res = resource_from_json(
+                GET([resources_path, id, "uptime"].join("/")).body
+              )
+        Yao::Resources::Hypervisor::Uptime.new(res)
+      end
     end
 
     class Statistics < OpenStruct; end
+    class Uptime     < OpenStruct; end
   end
 end

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -60,4 +60,27 @@ class TestHypervisor < Test::Unit::TestCase
     s = Yao::Resources::Hypervisor.statistics
     assert_equal(s.count, 1)
   end
+
+  def test_uptime
+    stub_request(:get, "https://example.com:12345/os-hypervisors/1/uptime")
+      .with(headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.12.2'})
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+            "hypervisor": {
+                "hypervisor_hostname": "fake-mini",
+                "id": 1,
+                "state": "up",
+                "status": "enabled",
+                "uptime": " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"
+            }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    u = Yao::Resources::Hypervisor.uptime(1)
+    assert_equal(u.uptime, " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14")
+  end
 end

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -1,5 +1,3 @@
-require "time"
-
 class TestHypervisor < Test::Unit::TestCase
   def test_hypervisor
     params = {
@@ -8,5 +6,28 @@ class TestHypervisor < Test::Unit::TestCase
 
     host = Yao::Hypervisor.new(params)
     assert_equal(host.enabled?, true)
+  end
+
+  def setup
+    Yao.default_client.pool["compute"] = Yao::Client.gen_client("https://example.com:12345")
+  end
+
+  def test_list_detail
+    stub_request(:get, "https://example.com:12345/os-hypervisors/detail")
+      .with(headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.12.2'})
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "hypervisors": [{
+            "id": "dummy"
+          }]
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    h = Yao::Resources::Hypervisor.list_detail
+    assert_equal(h.first.id, "dummy")
   end
 end

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -30,4 +30,34 @@ class TestHypervisor < Test::Unit::TestCase
     h = Yao::Resources::Hypervisor.list_detail
     assert_equal(h.first.id, "dummy")
   end
+
+  def test_statistics
+    stub_request(:get, "https://example.com:12345/os-hypervisors/statistics")
+      .with(headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Faraday v0.12.2'})
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "hypervisor_statistics": {
+            "count": 1,
+            "current_workload": 0,
+            "disk_available_least": 0,
+            "free_disk_gb": 1028,
+            "free_ram_mb": 7680,
+            "local_gb": 1028,
+            "local_gb_used": 0,
+            "memory_mb": 8192,
+            "memory_mb_used": 512,
+            "running_vms": 0,
+            "vcpus": 2,
+            "vcpus_used": 0
+          }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    s = Yao::Resources::Hypervisor.statistics
+    assert_equal(s.count, 1)
+  end
 end


### PR DESCRIPTION
Yao::Resources::Hypervisorに以下のメソッドを追加しました。

* [list_detail](https://developer.openstack.org/api-ref/compute/#list-hypervisors-details)
* [statistics](https://developer.openstack.org/api-ref/compute/#show-hypervisor-statistics)
* [uptime](https://developer.openstack.org/api-ref/compute/#show-hypervisor-uptime)