### PR TITLE
Fix error when action api return no content.

### DIFF
--- a/lib/yao/resources/action.rb
+++ b/lib/yao/resources/action.rb
@@ -5,7 +5,7 @@ module Yao::Resources
         req.body = query.to_json
         req.headers['Content-Type'] = 'application/json'
       end
-      return_resource(resource_from_json(res.body))
+      res.body ? return_resource(resource_from_json(res.body)) : nil
     end
 
     private


### PR DESCRIPTION
When yao shutdown instance, raise NoMethodError.

```ruby
Yao::Server.shutoff(instance_id)
```

Nova action api (os-stop) return no content (nil) if successful, but yao try to interpret json always.

```
NoMethodError: undefined method `[]' for nil:NilClass
  /hakata/vendor/bundle/ruby/2.3.0/gems/yao-0.3.8/lib/yao/resources/restfully_accessible.rb:136:in `resource_from_json'
  /hakata/vendor/bundle/ruby/2.3.0/gems/yao-0.3.8/lib/yao/resources/action.rb:8:in `action'
  /hakata/vendor/bundle/ruby/2.3.0/gems/yao-0.3.8/lib/yao/resources/server.rb:34:in `shutoff'
```

I fix that method action return nil if API return value is no content.