### PR TITLE
access REST API using dynamic generated url with api_version

### DIFF
--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -76,7 +76,7 @@ module Yao::Resources
 
     # restful methods
     def list(query={})
-      json = GET([api_version, resources_path].join('/'), query).body
+      json = GET([api_version, resources_path].select{|s| s != ''}.join('/'), query).body
       if @return_single_on_querying && !query.empty?
         return_resource(resource_from_json(json))
       else

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -29,7 +29,6 @@ module Yao::Resources
       @api_version = v
       api_version
     end
-    attr_reader :api_version
 
     def admin=(bool)
       @admin = bool

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -76,7 +76,7 @@ module Yao::Resources
 
     # restful methods
     def list(query={})
-      json = GET([api_version, resources_path], query).body
+      json = GET([api_version, resources_path].join('/'), query).body
       if @return_single_on_querying && !query.empty?
         return_resource(resource_from_json(json))
       else
@@ -86,7 +86,7 @@ module Yao::Resources
 
     def get(id_or_name_or_permalink, query={})
       res = if id_or_name_or_permalink.start_with?("http://", "https://")
-              GET(api_version, id_or_name_or_permalink, query)
+              GET([api_version, id_or_name_or_permalink].join('/'), query)
             elsif uuid?(id_or_name_or_permalink)
               GET([api_version, resources_path, id_or_name_or_permalink].join("/"), query)
             else
@@ -105,7 +105,7 @@ module Yao::Resources
       params = {
         resource_name_in_json => resource_params
       }
-      res = POST([api_version, resources_path]) do |req|
+      res = POST([api_version, resources_path].join('/')) do |req|
         req.body = params.to_json
         req.headers['Content-Type'] = 'application/json'
       end

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -86,7 +86,7 @@ module Yao::Resources
 
     def get(id_or_name_or_permalink, query={})
       res = if id_or_name_or_permalink.start_with?("http://", "https://")
-              GET([api_version, id_or_name_or_permalink].join('/'), query)
+              GET(id_or_name_or_permalink, query)
             elsif uuid?(id_or_name_or_permalink)
               GET([api_version, resources_path, id_or_name_or_permalink].join("/"), query)
             else

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -20,6 +20,10 @@ module Yao::Resources
     end
     attr_reader :service
 
+    def api_version
+      @api_version || ''
+    end
+
     def api_version=(v)
       raise("Set api_version after service is declared") unless service
       @api_version = v


### PR DESCRIPTION
I failed to get LoadBalancer resource with some execution `Yao.configure` . LoadBalancer resource has `api_version` parameter, it hasn't set when called Yao.configure second time.
So, I change to generate url with api_version each time.

```ruby
require 'yao'

def run
  Yao.configure do
    auth_url    ENV['OS_AUTH_URL']
    username    ENV['OS_USERNAME']
    password    ENV['OS_PASSWORD']
    tenant_name ENV['OS_TENANT_NAME']
    client_cert ENV['OS_CERT']
    client_key  ENV['OS_KEY']
  end

  p Yao::LoadBalancer.get('8cc3c516-809b-4724-931b-67858ccb2c10').id
end

puts "1回目============================================================================================="
run

puts "2回目============================================================================================="
run
```

```
➤ envchain nyah-tech bundle exec ruby ./invalid_endpoint.rb
1回目=============================================================================================
"8cc3c516-809b-4724-931b-67858ccb2c10"
2回目=============================================================================================
Traceback (most recent call last):
        13: from ./invalid_endpoint.rb:20:in `<main>'
        12: from ./invalid_endpoint.rb:13:in `run'
        11: from /Users/r_takaishi/src/github.com/takaishi/yao/lib/yao/resources/restfully_accessible.rb:91:in `get'
        10: from /Users/r_takaishi/src/github.com/takaishi/yao/vendor/bundle/ruby/2.5.0/gems/faraday-0.12.1/lib/faraday/connection.rb:149:in `get'
         9: from /Users/r_takaishi/src/github.com/takaishi/yao/vendor/bundle/ruby/2.5.0/gems/faraday-0.12.1/lib/faraday/connection.rb:386:in `run_request'
         8: from /Users/r_takaishi/src/github.com/takaishi/yao/vendor/bundle/ruby/2.5.0/gems/faraday-0.12.1/lib/faraday/rack_builder.rb:139:in `build_response'
         7: from /Users/r_takaishi/src/github.com/takaishi/yao/lib/yao/faraday_middlewares.rb:12:in `call'
         6: from /Users/r_takaishi/src/github.com/takaishi/yao/vendor/bundle/ruby/2.5.0/gems/faraday-0.12.1/lib/faraday/request/url_encoded.rb:15:in `call'
         5: from /Users/r_takaishi/src/github.com/takaishi/yao/lib/yao/faraday_middlewares.rb:29:in `call'
         4: from /Users/r_takaishi/src/github.com/takaishi/yao/lib/yao/faraday_middlewares.rb:40:in `call'
         3: from /Users/r_takaishi/src/github.com/takaishi/yao/vendor/bundle/ruby/2.5.0/gems/faraday-0.12.1/lib/faraday/response.rb:8:in `call'
         2: from /Users/r_takaishi/src/github.com/takaishi/yao/vendor/bundle/ruby/2.5.0/gems/faraday-0.12.1/lib/faraday/response.rb:61:in `on_complete'
         1: from /Users/r_takaishi/src/github.com/takaishi/yao/vendor/bundle/ruby/2.5.0/gems/faraday-0.12.1/lib/faraday/response.rb:9:in `block in call'
/Users/r_takaishi/src/github.com/takaishi/yao/lib/yao/faraday_middlewares.rb:128:in `on_complete': The resource could not be found. (Yao::NotFound)
```