### PR TITLE
role_assignment url_prefix is invalid

### DIFF
--- a/lib/yao/resources/role_assignment.rb
+++ b/lib/yao/resources/role_assignment.rb
@@ -6,7 +6,7 @@ module Yao::Resources
     self.resources_name  = "role_assignments"
     self.admin          = true
     self.api_version    = "v3"
-    self.client.url_prefix = Yao.config.auth_url.gsub('v2.0', 'v3')
+    self.client.url_prefix = Yao.config.auth_url.gsub('v2.0', '')
 
     def project
       @project ||= Yao::Tenant.get(scope["project"]["id"])


### PR DESCRIPTION
When use v0.4.3, can not fetch role assignment list. https://github.com/yaocloud/yao/pull/82 changes to generate url with api_version, so role_assignments's url become invalid.
Correct url is `https://openstack.endpoint/auth/v3/role_assignments`, delete `v2.0` from url_prefix.

```
================================
 OpenStack response inspection:
================================
Requested To: "https://openstack.endpoint/auth/v3/v3/role_assignments"


Body:
{"error"=>
  {"message"=>"The resource could not be found.",
   "code"=>404,
   "title"=>"Not Found"}}
```