### PR TITLE
api version attach dynamic, so remove v3 from url_prefix with keystone v3 api

### DIFF
--- a/lib/yao/resources/role_assignment.rb
+++ b/lib/yao/resources/role_assignment.rb
@@ -6,7 +6,7 @@ module Yao::Resources
     self.resources_name  = "role_assignments"
     self.admin          = true
     self.api_version    = "v3"
-    self.client.url_prefix = Yao.config.auth_url.gsub('v2.0', '')
+    self.client.url_prefix = Yao.config.auth_url.gsub(/v2.0|v3/, '')
 
     def project
       @project ||= Yao::Tenant.get(scope["project"]["id"])


### PR DESCRIPTION
I fixed role_assignment list api on https://github.com/yaocloud/yao/pull/85, but error occured with keystone v3 api.
I will replace `v3` to empty string because auth_url has `v3` keyword with v3 api, 