### PR TITLE
Delete duplicate method Yao::Resource::Tenant.get_by_name

### DIFF
--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -25,11 +25,6 @@ module Yao::Resources
     end
 
     class << self
-      def get_by_name(name)
-        self.list(name: name)
-      end
-      alias find_by_name get_by_name
-
       def accessible
         as_member { self.list }
       end


### PR DESCRIPTION
Using Yao::Tenant.get causes an error.

```
Traceback (most recent call last):
        2: from ./tenants.rb:5:in `<main>'
        1: from /home/ykky/src/github.com/yaocloud/yao/lib/yao/resources/restfully_accessible.rb:93:in `get'
/home/ykky/src/github.com/yaocloud/yao/lib/yao/resources/tenant.rb:28:in `get_by_name': wrong number of arguments (given 2, expected 1) (ArgumentError)
```

Delete because it is caused by duplicate Yao::Resource::Tenant.get_by_name