### PR TITLE
Fix Yao::OldSample broken

### DIFF
--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -31,7 +31,7 @@ module Yao::Resources
     # get /v2/meters/{id} returns samples!
     def self.list(meter_name, query={})
       cache_key = [meter_name, *query].join
-      cache[cache_key] = GET("meters/#{meter_name}", query).body unless cache[cache_key]
+      cache[cache_key] = GET("#{self.api_version}/meters/#{meter_name}", query).body unless cache[cache_key]
       return_resources(cache[cache_key])
     end
 


### PR DESCRIPTION
When #82 was merged Yao::OldSsample came to return 404.
The reason is that api_version is not included in the URI.