### PR TITLE
Yao::Resources::FloatingIP V2

### DIFF
--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -1,9 +1,26 @@
 module Yao::Resources
   class FloatingIP < Base
-    friendly_attributes :fixed_ip, :instance_id, :ip, :pool
+    friendly_attributes :router_id, :description, :dns_domain, :dns_name,
+                        :revision_number, :project_id, :tenant_id,
+                        :floating_network_id, :fixed_ip_address,
+                        :floating_ip_address, :port_id,
+                        :status, :port_details, :tags, :port_forwardings
 
-    self.service        = "compute"
-    self.resource_name  = "os-floating-ip"
-    self.resources_name = "os-floating-ips"
+    self.service        = "network"
+    self.resource_name  = "floatingip"
+    self.resources_name = "floatingips"
+
+    def router
+      @router ||= Yao::Router.get(router_id)
+    end
+
+    def project
+      @project ||= Yao::Tenant.get(project_id)
+    end
+    alias :tenant :project
+
+    def port
+      @port ||= Yao::Port.find(port_id)
+    end
   end
 end

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -1,0 +1,60 @@
+class TestRole < Test::Unit::TestCase
+  def test_floating_ip
+    params = {
+      "router_id" => "d23abc8d-2991-4a55-ba98-2aaea84cc72f",
+      "description" => "for test",
+      "dns_domain" => "my-domain.org.",
+      "dns_name" => "myfip",
+      "created_at" => "2016-12-21T10:55:50Z",
+      "updated_at" => "2016-12-21T10:55:53Z",
+      "revision_number" => 1,
+      "project_id" => "4969c491a3c74ee4af974e6d800c62de",
+      "tenant_id" => "4969c491a3c74ee4af974e6d800c62de",
+      "floating_network_id" => "376da547-b977-4cfe-9cba-275c80debf57",
+      "fixed_ip_address" => "10.0.0.3",
+      "floating_ip_address" => "172.24.4.228",
+      "port_id" => "ce705c24-c1ef-408a-bda3-7bbd946164ab",
+      "id" => "2f245a7b-796b-4f26-9cf9-9e82d248fda7",
+      "status" => "ACTIVE",
+      "port_details" => {
+        "status" => "ACTIVE",
+        "name" => "",
+        "admin_state_up" => true,
+        "network_id" => "02dd8479-ef26-4398-a102-d19d0a7b3a1f",
+        "device_owner" => "compute:nova",
+        "mac_address" => "fa:16:3e:b1:3b:30",
+        "device_id" => "8e3941b4-a6e9-499f-a1ac-2a4662025cba"
+      },
+      "tags" => ["tag1,tag2"],
+      "port_forwardings" => []
+    }
+
+    fip = Yao::Resources::FloatingIP.new(params)
+    assert_equal(fip.router_id, "d23abc8d-2991-4a55-ba98-2aaea84cc72f")
+    assert_equal(fip.description, "for test")
+    assert_equal(fip.dns_domain, "my-domain.org.")
+    assert_equal(fip.dns_name, "myfip")
+    assert_equal(fip.created, Time.parse("2016-12-21T10:55:50Z"))
+    assert_equal(fip.updated, Time.parse("2016-12-21T10:55:53Z"))
+    assert_equal(fip.revision_number, 1)
+    assert_equal(fip.project_id, "4969c491a3c74ee4af974e6d800c62de")
+    assert_equal(fip.tenant_id, "4969c491a3c74ee4af974e6d800c62de")
+    assert_equal(fip.floating_network_id, "376da547-b977-4cfe-9cba-275c80debf57")
+    assert_equal(fip.fixed_ip_address, "10.0.0.3")
+    assert_equal(fip.floating_ip_address, "172.24.4.228")
+    assert_equal(fip.port_id, "ce705c24-c1ef-408a-bda3-7bbd946164ab")
+    assert_equal(fip.id, "2f245a7b-796b-4f26-9cf9-9e82d248fda7")
+    assert_equal(fip.status, "ACTIVE")
+    assert_equal(fip.tags, ["tag1,tag2"])
+    assert_equal(fip.port_details, {
+        "status" => "ACTIVE",
+        "name" => "",
+        "admin_state_up" => true,
+        "network_id" => "02dd8479-ef26-4398-a102-d19d0a7b3a1f",
+        "device_owner" => "compute:nova",
+        "mac_address" => "fa:16:3e:b1:3b:30",
+        "device_id" => "8e3941b4-a6e9-499f-a1ac-2a4662025cba"
+    })
+    assert_equal(fip.port_forwardings, [])
+  end
+end

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -79,7 +79,7 @@ class TestRole < Test::Unit::TestCase
       )
 
     fip = Yao::FloatingIP.new("router_id" => "00000000-0000-0000-0000-000000000000")
-    assert { fip.router.is_a? Yao::Router }
+    assert_instance_of(Yao::Router, fip.router)
   end
 
   def test_floating_to_tenant
@@ -102,8 +102,8 @@ class TestRole < Test::Unit::TestCase
       "tenant_id"  => "0123456789abcdef0123456789abcdef",
     )
 
-    assert { fip.tenant.is_a? Yao::Tenant }
-    assert { fip.project.is_a? Yao::Tenant }
+    assert_instance_of(Yao::Tenant, fip.tenant)
+    assert_instance_of(Yao::Tenant, fip.project)
   end
 
   def test_floating_ip_to_router
@@ -122,6 +122,6 @@ class TestRole < Test::Unit::TestCase
       )
 
     fip = Yao::FloatingIP.new("port_id" => "00000000-0000-0000-0000-000000000000")
-    assert { fip.port.is_a? Yao::Port }
+    assert_instance_of(Yao::Port, fip.port)
   end
 end


### PR DESCRIPTION
Hi chao! Hi yao ☁️ !

## What does changes in this PR ? 

 * This PR changes `Yao::Resources::FloatingIP` to support network V2 API 
   * ref https://docs.openstack.org/api-ref/network/v2/?expanded=list-floating-ips-detail#floating-ips-floatingips
 * And also it deprecates old API interafaces
   * ref https://docs.openstack.org/api-ref/compute/#floating-ips-os-floating-ips-deprecated. 

## Notice

This change break backwards compability 💣 

## Thanks 

The original code snippet was written by @takaishi . Thx !
