### PR TITLE
fix test notification

### DIFF
--- a/test/yao/resources/test_aggregates.rb
+++ b/test/yao/resources/test_aggregates.rb
@@ -1,7 +1,7 @@
 require "time"
 require "date"
 
-class TestRole < Test::Unit::TestCase
+class TestAggregates < Test::Unit::TestCase
   def test_server_aggregates
     params = {
       "availability_zone" => "nova",

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -106,7 +106,7 @@ class TestFloatingIP < Test::Unit::TestCase
     assert_instance_of(Yao::Tenant, fip.project)
   end
 
-  def test_floating_ip_to_router
+  def test_floating_ip_to_port
 
     stub_request(:get, "http://neutron-endpoint.example.com:9696/v2.0/ports/00000000-0000-0000-0000-000000000000")
       .to_return(

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -1,7 +1,9 @@
 class TestFloatingIP < Test::Unit::TestCase
 
   def setup
-    Yao.default_client.pool["compute"] = Yao::Client.gen_client("https://example.com:12345")
+    Yao.default_client.admin_pool["identity"] = Yao::Client.gen_client("https://example.com:12345")
+    Yao.default_client.pool["network"]  = Yao::Client.gen_client("https://example.com:12345")
+    Yao.default_client.pool["compute"]  = Yao::Client.gen_client("https://example.com:12345")
   end
 
   def test_floating_ip
@@ -65,7 +67,7 @@ class TestFloatingIP < Test::Unit::TestCase
 
   def test_floating_ip_to_router
 
-    stub_request(:get, "http://neutron-endpoint.example.com:9696/v2.0/routers/00000000-0000-0000-0000-000000000000")
+    stub_request(:get, "https://example.com:12345/routers/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -84,7 +86,7 @@ class TestFloatingIP < Test::Unit::TestCase
 
   def test_floating_to_tenant
 
-    stub_request(:get, "http://endpoint.example.com:12345/v2.0/tenants/0123456789abcdef0123456789abcdef")
+    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(
          status: 200,
          body: <<-JSON,
@@ -108,7 +110,7 @@ class TestFloatingIP < Test::Unit::TestCase
 
   def test_floating_ip_to_port
 
-    stub_request(:get, "http://neutron-endpoint.example.com:9696/v2.0/ports/00000000-0000-0000-0000-000000000000")
+    stub_request(:get, "https://example.com:12345/ports/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -1,4 +1,4 @@
-class TestRole < Test::Unit::TestCase
+class TestFloatingIP < Test::Unit::TestCase
 
   def setup
     Yao.default_client.pool["compute"] = Yao::Client.gen_client("https://example.com:12345")

--- a/test/yao/resources/test_loadbalancer.rb
+++ b/test/yao/resources/test_loadbalancer.rb
@@ -1,6 +1,6 @@
 require "time"
 
-class TestRole < Test::Unit::TestCase
+class TestLoadBalancer < Test::Unit::TestCase
   def test_loadbalancer
     params = {
       "provider" => "octavia",

--- a/test/yao/resources/test_loadbalancer_healthmonitor.rb
+++ b/test/yao/resources/test_loadbalancer_healthmonitor.rb
@@ -1,6 +1,6 @@
 require "time"
 
-class TestRole < Test::Unit::TestCase
+class TestLoadBalancerHealthMonitor < Test::Unit::TestCase
   def test_loadbalancer_healtchmonitor
     params = {
       "name" => "super-pool-health-monitor",

--- a/test/yao/resources/test_loadbalancer_listener.rb
+++ b/test/yao/resources/test_loadbalancer_listener.rb
@@ -1,6 +1,6 @@
 require "time"
 
-class TestRole < Test::Unit::TestCase
+class TestLoadBalancerListener < Test::Unit::TestCase
   def test_loadbalancer_listener
     params = {
       "description" => "A great TLS listener",

--- a/test/yao/resources/test_loadbalancer_pool.rb
+++ b/test/yao/resources/test_loadbalancer_pool.rb
@@ -1,6 +1,6 @@
 require "time"
 
-class TestRole < Test::Unit::TestCase
+class TestLoadBalancerPool < Test::Unit::TestCase
   def test_loadbalancer_pool
     params = {
       "lb_algorithm" => "ROUND_ROBIN",

--- a/test/yao/resources/test_loadbalancer_pool_member.rb
+++ b/test/yao/resources/test_loadbalancer_pool_member.rb
@@ -1,6 +1,6 @@
 require "time"
 
-class TestRole < Test::Unit::TestCase
+class TestLoadBalancerPoolMember < Test::Unit::TestCase
   def test_loadbalancer_pool_member
     params = {
       "monitor_port" => 8080,

--- a/test/yao/resources/test_volume.rb
+++ b/test/yao/resources/test_volume.rb
@@ -1,4 +1,4 @@
-class TestRole < Test::Unit::TestCase
+class TestVolume < Test::Unit::TestCase
   def test_volume
     params = {
         'name' => 'cinder',

--- a/test/yao/resources/test_volume_type.rb
+++ b/test/yao/resources/test_volume_type.rb
@@ -1,4 +1,4 @@
-class TestRole < Test::Unit::TestCase
+class TestVolumeType < Test::Unit::TestCase
   def test_volume
     params = {
         'name' => 'test_volume',


### PR DESCRIPTION
I found that `bundle exec rake test` raises a Notification. 

```
/path/to/git/yao/test/yao/resources/test_volume_type.rb:2:in `<class:TestRole>'
Notification: <TestRole#test_volume> was redefined [test_volume(TestRole)]
```

This PR fixes the notification.  

## Before

<img width="662" alt="image" src="https://user-images.githubusercontent.com/172456/62750692-fbe07800-ba9b-11e9-87b2-105cd57d2df7.png">

## After 

<img width="645" alt="image" src="https://user-images.githubusercontent.com/172456/62751116-8ecde200-ba9d-11e9-9ee9-333f84641e7d.png">

## 👀 many TestRole classes ... 

なんてことでしょう!!! `class TestRole` is duplicated まくり.  

```
$ ag TestRole test
test/yao/resources/test_loadbalancer_pool_member.rb
3:class TestRole < Test::Unit::TestCase

test/yao/resources/test_loadbalancer_listener.rb
3:class TestRole < Test::Unit::TestCase

test/yao/resources/test_aggregates.rb
4:class TestRole < Test::Unit::TestCase

test/yao/resources/test_loadbalancer_healthmonitor.rb
3:class TestRole < Test::Unit::TestCase

test/yao/resources/test_role.rb
1:class TestRole < Test::Unit::TestCase

test/yao/resources/test_loadbalancer.rb
3:class TestRole < Test::Unit::TestCase

test/yao/resources/test_volume_type.rb
1:class TestRole < Test::Unit::TestCase

test/yao/resources/test_loadbalancer_pool.rb
3:class TestRole < Test::Unit::TestCase
```

Should I rename also these classes in this PR? 

## 日本語で ok 

 - test で  `Notification` でているのを直す PR です
   - TestRole クラスが重複しているのが原因
 - 他にも TestRole クラスがたくさんあるんだけど、これも PR で直しておいたらいい?