### PR TITLE
Add method chain: Yao::Resouces::*#tenant returns Yao::Tenant 

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -1,6 +1,7 @@
 module Yao
   module Resources
     require "yao/resources/base"
+    require "yao/resources/tenant_associationable"
 
     autoload :Server,                    "yao/resources/server"
     autoload :Flavor,                    "yao/resources/flavor"

--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -1,7 +1,10 @@
 module Yao::Resources
   class FloatingIP < Base
+
+    include TenantAssociationable
+
     friendly_attributes :router_id, :description, :dns_domain, :dns_name,
-                        :revision_number, :project_id, :tenant_id,
+                        :revision_number,
                         :floating_network_id, :fixed_ip_address,
                         :floating_ip_address, :port_id,
                         :status, :port_details, :tags, :port_forwardings

--- a/lib/yao/resources/meter.rb
+++ b/lib/yao/resources/meter.rb
@@ -1,6 +1,9 @@
 module Yao::Resources
   class Meter < Base
-    friendly_attributes :meter_id, :name, :user_id, :resource_id, :project_id, :source, :type, :unit
+
+    include TenantAssociationable
+
+    friendly_attributes :meter_id, :name, :user_id, :resource_id, :source, :type, :unit
 
     def id
       meter_id
@@ -8,10 +11,6 @@ module Yao::Resources
 
     def resource
       @resource ||= Yao::Resource.get(resource_id)
-    end
-
-    def tenant
-      @tenant ||= Yao::Tenant.get(project_id)
     end
 
     def user

--- a/lib/yao/resources/network.rb
+++ b/lib/yao/resources/network.rb
@@ -1,6 +1,8 @@
 module Yao::Resources
   class Network < Base
-    friendly_attributes :name, :status, :shared, :tenant_id, :subnets, :admin_state_up
+    include TenantAssociationable
+
+    friendly_attributes :name, :status, :shared, :subnets, :admin_state_up
     map_attribute_to_attribute "provider:physical_network" => :physical_network
     map_attribute_to_attribute "provider:network_type"     => :type
     map_attribute_to_attribute "provider:segmentation_id"  => :segmentation_id

--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -1,7 +1,9 @@
 module Yao::Resources
   class OldSample < Base
+    include TenantAssociationable
+
     friendly_attributes :counter_name, :counter_type, :counter_unit, :counter_volume,
-                        :message_id, :project_id, :resource_id, :timestamp, :resource_metadata, :user_id,
+                        :message_id, :resource_id, :timestamp, :resource_metadata, :user_id,
                         :source
 
     def recorded_at
@@ -15,10 +17,6 @@ module Yao::Resources
 
     def resource
       @resource ||= Yao::Resource.get(resource_id)
-    end
-
-    def tenant
-      @tenant ||= Yao::Tenant.get(project_id)
     end
 
     def user

--- a/lib/yao/resources/port.rb
+++ b/lib/yao/resources/port.rb
@@ -17,6 +17,10 @@ module Yao::Resources
       Yao::Network.find network_id
     end
 
+    def tenant
+      Yao::Tenant.find tenant_id
+    end
+
     self.service        = "network"
     self.resource_name  = "port"
     self.resources_name = "ports"

--- a/lib/yao/resources/port.rb
+++ b/lib/yao/resources/port.rb
@@ -1,8 +1,11 @@
 module Yao::Resources
   class Port < Base
+
+    include TenantAssociationable
+
     friendly_attributes :name, :mac_address, :status, :allowed_address_pairs,
                         :device_owner, :fixed_ips, :security_groups, :device_id,
-                        :network_id, :tenant_id, :admin_state_up
+                        :network_id, :admin_state_up
     map_attribute_to_attribute "binding:host_id" => :host_id
 
     def primary_ip
@@ -15,10 +18,6 @@ module Yao::Resources
 
     def network
       Yao::Network.find network_id
-    end
-
-    def tenant
-      Yao::Tenant.find tenant_id
     end
 
     self.service        = "network"

--- a/lib/yao/resources/resource.rb
+++ b/lib/yao/resources/resource.rb
@@ -1,17 +1,15 @@
 require 'time'
 module Yao::Resources
   class Resource < Base
-    friendly_attributes :user_id, :resource_id, :project_id,
+    include TenantAssociationable
+
+    friendly_attributes :user_id, :resource_id,
                         :last_sample_timestamp, :first_sample_timestamp,
                         :metadata,
                         :links
 
     def id
       resource_id
-    end
-
-    def tenant
-      @tenant ||= Yao::User.get(project_id)
     end
 
     def user

--- a/lib/yao/resources/router.rb
+++ b/lib/yao/resources/router.rb
@@ -1,6 +1,8 @@
 module Yao::Resources
   class Router < Base
-    friendly_attributes :tenant_id, :project_id, :name, :description, :admin_state_up, :status, :external_gateway_info,
+    include TenantAssociationable
+
+    friendly_attributes :name, :description, :admin_state_up, :status, :external_gateway_info,
                         :network_id, :enable_snat, :external_fixed_ips, :routes, :destination, :nexthop, :distributed,
                         :ha, :availability_zone_hints, :availability_zones
 

--- a/lib/yao/resources/sample.rb
+++ b/lib/yao/resources/sample.rb
@@ -2,7 +2,7 @@ module Yao::Resources
   class Sample < Base
     friendly_attributes :id, :metadata, :meter,
                         :source, :type, :unit, :volume,
-                        :resouce_id, :tenant_id, :user_id
+                        :resouce_id, :user_id
 
     def recorded_at
       Time.parse(self["recorded_at"])
@@ -14,10 +14,6 @@ module Yao::Resources
 
     def resource
       @resource ||= Yao::Resource.get(resource_id)
-    end
-
-    def tenant
-      @tenant ||= Yao::Tenant.get(project_id)
     end
 
     def user

--- a/lib/yao/resources/security_group.rb
+++ b/lib/yao/resources/security_group.rb
@@ -1,7 +1,9 @@
 require 'yao/resources/security_group_rule'
 module Yao::Resources
   class SecurityGroup < Base
-    friendly_attributes :name, :description, :tenant_id
+    include TenantAssociationable
+
+    friendly_attributes :name, :description
 
     def rules
       self[["rules", SecurityGroupRule].join("__")] ||= (case self.class.service

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -2,8 +2,10 @@ require 'yao/resources/metadata_available'
 require 'yao/resources/action'
 module Yao::Resources
   class Server < Base
+    include TenantAssociationable
+
     friendly_attributes :addresses, :metadata, :name, :progress,
-                        :status, :tenant_id, :user_id, :key_name
+                        :status, :user_id, :key_name
     map_attribute_to_attribute hostId: :host_id
     map_attribute_to_resource  flavor: Flavor
     map_attribute_to_resource  image: Image

--- a/lib/yao/resources/subnet.rb
+++ b/lib/yao/resources/subnet.rb
@@ -1,6 +1,8 @@
 module Yao::Resources
   class Subnet < Base
-    friendly_attributes :name, :cidr, :gateway_ip, :network_id, :tenant_id, :ip_version,
+    include TenantAssociationable
+
+    friendly_attributes :name, :cidr, :gateway_ip, :network_id, :ip_version,
                         :dns_nameservers, :host_routes, :enable_dhcp
 
     def allocation_pools

--- a/lib/yao/resources/tenant_associationable.rb
+++ b/lib/yao/resources/tenant_associationable.rb
@@ -8,7 +8,7 @@ module Yao
       end
 
       def tenant
-        Yao::Tenant.find tenant_id
+        Yao::Tenant.find(project_id || tenant_id)
       end
 
       alias :project :tenant

--- a/lib/yao/resources/tenant_associationable.rb
+++ b/lib/yao/resources/tenant_associationable.rb
@@ -3,8 +3,8 @@ module Yao
     module TenantAssociationable
 
       def self.included(base)
-        base.friendly_attributes :tenant_id
         base.friendly_attributes :project_id
+        base.friendly_attributes :tenant_id
       end
 
       def tenant

--- a/lib/yao/resources/tenant_associationable.rb
+++ b/lib/yao/resources/tenant_associationable.rb
@@ -4,11 +4,14 @@ module Yao
 
       def self.included(base)
         base.friendly_attributes :tenant_id
+        base.friendly_attributes :project_id
       end
 
       def tenant
         Yao::Tenant.find tenant_id
       end
+
+      alias :project :tenant
     end
   end
 end

--- a/lib/yao/resources/tenant_associationable.rb
+++ b/lib/yao/resources/tenant_associationable.rb
@@ -1,0 +1,14 @@
+module Yao
+  module Resources
+    module TenantAssociationable
+
+      def self.included(base)
+        base.friendly_attributes :tenant_id
+      end
+
+      def tenant
+        Yao::Tenant.find tenant_id
+      end
+    end
+  end
+end

--- a/lib/yao/resources/tenant_associationable.rb
+++ b/lib/yao/resources/tenant_associationable.rb
@@ -8,7 +8,7 @@ module Yao
       end
 
       def tenant
-        Yao::Tenant.find(project_id || tenant_id)
+        @tenant ||= Yao::Tenant.find(project_id || tenant_id)
       end
 
       alias :project :tenant

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -91,9 +91,9 @@ class TestFloatingIP < Test::Unit::TestCase
          status: 200,
          body: <<-JSON,
         {
-          "tenants": [{
+          "tenant": {
             "id": "0123456789abcdef0123456789abcdef"
-          }]
+          }
         }
         JSON
         headers: {'Content-Type' => 'application/json'}
@@ -106,6 +106,8 @@ class TestFloatingIP < Test::Unit::TestCase
 
     assert_instance_of(Yao::Tenant, fip.tenant)
     assert_instance_of(Yao::Tenant, fip.project)
+
+    assert_equal(fip.tenant.id, '0123456789abcdef0123456789abcdef')
   end
 
   def test_floating_ip_to_port

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -84,7 +84,7 @@ class TestFloatingIP < Test::Unit::TestCase
     assert_instance_of(Yao::Router, fip.router)
   end
 
-  def test_floating_to_tenant
+  def test_tenant
 
     stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(

--- a/test/yao/resources/test_network.rb
+++ b/test/yao/resources/test_network.rb
@@ -35,4 +35,30 @@ class TestNetwork < Test::Unit::TestCase
     assert_equal(network.type, "vlan")
     assert_equal(network.segmentation_id, 1000)
   end
+
+  def test_network_to_tenant
+
+    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+      .to_return(
+         status: 200,
+         body: <<-JSON,
+        {
+          "tenant": {
+            "id": "0123456789abcdef0123456789abcdef"
+          }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    network = Yao::Network.new(
+      "project_id" => "0123456789abcdef0123456789abcdef",
+      "tenant_id"  => "0123456789abcdef0123456789abcdef",
+    )
+
+    assert_instance_of(Yao::Tenant, network.tenant)
+    assert_instance_of(Yao::Tenant, network.project)
+
+    assert_equal(network.tenant.id, '0123456789abcdef0123456789abcdef')
+  end
 end

--- a/test/yao/resources/test_network.rb
+++ b/test/yao/resources/test_network.rb
@@ -36,7 +36,7 @@ class TestNetwork < Test::Unit::TestCase
     assert_equal(network.segmentation_id, 1000)
   end
 
-  def test_network_to_tenant
+  def test_tenant
 
     stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -1,4 +1,9 @@
 class TestPort < Test::Unit::TestCase
+
+  def setup
+    Yao.default_client.pool["compute"] = Yao::Client.gen_client("https://example.com:12345")
+  end
+
   def test_port
 
     # https://docs.openstack.org/api-ref/network/v2/?expanded=list-floating-ips-detail,show-port-details-detail#ports
@@ -71,5 +76,24 @@ class TestPort < Test::Unit::TestCase
 
     # map_attribute_to_attribute
     assert_equal(port.host_id, "compute-000")
+  end
+
+  def test_port_to_tenant
+
+    stub_request(:get, "http://endpoint.example.com:12345/v2.0/tenants/0123456789abcdef0123456789abcdef")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "tenants": [{
+            "id": "0123456789abcdef0123456789abcdef"
+          }]
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    port = Yao::Port.new('tenant_id' => '0123456789abcdef0123456789abcdef')
+    assert { port.tenant.is_a? Yao::Tenant }
   end
 end

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -1,0 +1,75 @@
+class TestPort < Test::Unit::TestCase
+  def test_port
+
+    # https://docs.openstack.org/api-ref/network/v2/?expanded=list-floating-ips-detail,show-port-details-detail#ports
+    params = {
+      "admin_state_up" => true,
+      "allowed_address_pairs" => [],
+      "created_at" => "2016-03-08T20:19:41",
+      "data_plane_status" => "ACTIVE",
+      "description" => "",
+      "device_id" => "5e3898d7-11be-483e-9732-b2f5eccd2b2e",
+      "device_owner" => "network:router_interface",
+      "dns_assignment" => {
+        "hostname" => "myport",
+        "ip_address" => "10.0.0.1",
+        "fqdn" => "myport.my-domain.org"
+      },
+      "dns_domain" => "my-domain.org.",
+      "dns_name" => "myport",
+      "extra_dhcp_opts" => [
+        {
+          "opt_value" => "pxelinux.0",
+          "ip_version" => 4,
+          "opt_name" => "bootfile-name"
+        }
+      ],
+      "fixed_ips" => [
+        {
+          "ip_address" => "10.0.0.1",
+          "subnet_id" => "a0304c3a-4f08-4c43-88af-d796509c97d2"
+        }
+      ],
+      "id" => "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2",
+      "ip_allocation" => "immediate",
+      "mac_address" => "fa:16:3e:23:fd:d7",
+      "name" => "foobar",
+      "network_id" => "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+      "port_security_enabled" => false,
+      "project_id" => "7e02058126cc4950b75f9970368ba177",
+      "revision_number" => 1,
+      "security_groups" => [],
+      "status" => "ACTIVE",
+      "tags" => ["tag1,tag2"],
+      "tenant_id" => "7e02058126cc4950b75f9970368ba177",
+      "updated_at" => "2016-03-08T20:19:41",
+      "qos_policy_id" => "29d5e02e-d5ab-4929-bee4-4a9fc12e22ae",
+      "uplink_status_propagation" => false,
+      "binding:host_id" => "compute-000",
+    }
+
+    port = Yao::Port.new(params)
+    assert_equal(port.id, "46d4bfb9-b26e-41f3-bd2e-e6dcc1ccedb2")
+
+    # friendly_attributes
+    assert_equal(port.name, "foobar")
+    assert_equal(port.mac_address, "fa:16:3e:23:fd:d7")
+    assert_equal(port.status, "ACTIVE")
+    assert_equal(port.allowed_address_pairs, [])
+    assert_equal(port.device_owner, "network:router_interface")
+    assert_equal(port.fixed_ips, [
+      {
+        "ip_address" => "10.0.0.1",
+        "subnet_id" => "a0304c3a-4f08-4c43-88af-d796509c97d2"
+      }
+    ])
+    assert_equal(port.security_groups, [])
+    assert_equal(port.device_id, "5e3898d7-11be-483e-9732-b2f5eccd2b2e")
+    assert_equal(port.network_id, "a87cc70a-3e15-4acf-8205-9b711a3531b7")
+    assert_equal(port.tenant_id, "7e02058126cc4950b75f9970368ba177")
+    assert_equal(port.admin_state_up, true)
+
+    # map_attribute_to_attribute
+    assert_equal(port.host_id, "compute-000")
+  end
+end

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -81,7 +81,7 @@ class TestPort < Test::Unit::TestCase
     assert_equal(port.primary_ip, "10.0.0.1")
   end
 
-  def test_port_to_tenant
+  def test_tenant
 
     stub_request(:get, "http://endpoint.example.com:12345/v2.0/tenants/0123456789abcdef0123456789abcdef")
       .to_return(

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -7,7 +7,7 @@ class TestPort < Test::Unit::TestCase
 
   def test_port
 
-    # https://docs.openstack.org/api-ref/network/v2/?expanded=list-floating-ips-detail,show-poart-details-detail#ports
+    # https://docs.openstack.org/api-ref/network/v2/?expanded=list-floating-ips-detail,show-port-details-detail#ports
     params = {
       "admin_state_up" => true,
       "allowed_address_pairs" => [],

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -116,21 +116,6 @@ class TestPort < Test::Unit::TestCase
     assert_equal(port.primary_ip, "10.0.0.1")
   end
 
-  def test_primary_ip
-
-    params = {
-      "fixed_ips" => [
-        {
-          "ip_address" => "10.0.0.1",
-          "subnet_id" => "a0304c3a-4f08-4c43-88af-d796509c97d2"
-        }
-      ],
-    }
-
-    port = Yao::Port.new(params)
-    assert_equal(port.primary_ip, "10.0.0.1")
-  end
-
   def test_primary_subnet
 
     stub_request(:get, "https://example.com:12345/subnets/00000000-0000-0000-0000-000000000000")

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -1,7 +1,6 @@
 class TestPort < Test::Unit::TestCase
 
   def setup
-    Yao.default_client.pool["compute"] = Yao::Client.gen_client("https://example.com:12345")
     Yao.default_client.pool["network"] = Yao::Client.gen_client("https://example.com:12345")
   end
 

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -88,16 +88,17 @@ class TestPort < Test::Unit::TestCase
         status: 200,
         body: <<-JSON,
         {
-          "tenants": [{
+          "tenant": {
             "id": "0123456789abcdef0123456789abcdef"
-          }]
+          }
         }
         JSON
         headers: {'Content-Type' => 'application/json'}
       )
 
     port = Yao::Port.new('tenant_id' => '0123456789abcdef0123456789abcdef')
-    assert { port.tenant.is_a? Yao::Tenant }
+    assert_instance_of(Yao::Tenant, port.tenant)
+    assert_equal(port.tenant.id, '0123456789abcdef0123456789abcdef')
   end
 
   def test_primary_ip

--- a/test/yao/resources/test_router.rb
+++ b/test/yao/resources/test_router.rb
@@ -130,4 +130,24 @@ class TestRouter < Test::Unit::TestCase
     assert_instance_of(Yao::Port, port)
     assert_equal(port.id, "00000000-0000-0000-0000-000000000000")
   end
+
+  def test_router_tenant
+
+    stub_request(:get, "http://endpoint.example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "tenant": {
+            "id": "0123456789abcdef0123456789abcdef"
+          }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    router = Yao::Router.new('tenant_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Tenant, router.tenant)
+    assert_equal(router.tenant.id, '0123456789abcdef0123456789abcdef')
+  end
 end

--- a/test/yao/resources/test_router.rb
+++ b/test/yao/resources/test_router.rb
@@ -131,7 +131,7 @@ class TestRouter < Test::Unit::TestCase
     assert_equal(port.id, "00000000-0000-0000-0000-000000000000")
   end
 
-  def test_router_tenant
+  def test_tenant
 
     stub_request(:get, "http://endpoint.example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(

--- a/test/yao/resources/test_security_group.rb
+++ b/test/yao/resources/test_security_group.rb
@@ -22,4 +22,24 @@ class TestSecurityGroup < Test::Unit::TestCase
     assert_equal(sg.description, "test_description_1")
     assert(sg.rules[0].instance_of?(Yao::SecurityGroupRule))
   end
+
+  def test_sg_to_tenant
+
+    stub_request(:get, "http://endpoint.example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "tenant": {
+            "id": "0123456789abcdef0123456789abcdef"
+          }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    sg = Yao::SecurityGroup.new('tenant_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Tenant, sg.tenant)
+    assert_equal(sg.tenant.id, '0123456789abcdef0123456789abcdef')
+  end
 end

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -162,7 +162,7 @@ class TestServer < Test::Unit::TestCase
     assert_equal(servers.first.id, 'dummy')
   end
 
-  def test_port_to_tenant
+  def test_tenant
 
     stub_request(:get, "http://endpoint.example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -161,4 +161,24 @@ class TestServer < Test::Unit::TestCase
     assert_instance_of(Yao::Server, servers.first)
     assert_equal(servers.first.id, 'dummy')
   end
+
+  def test_port_to_tenant
+
+    stub_request(:get, "http://endpoint.example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "tenant": {
+            "id": "0123456789abcdef0123456789abcdef"
+          }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    server = Yao::Server.new('tenant_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Tenant, server.tenant)
+    assert_equal(server.tenant.id, '0123456789abcdef0123456789abcdef')
+  end
 end

--- a/test/yao/resources/test_subnet.rb
+++ b/test/yao/resources/test_subnet.rb
@@ -77,4 +77,23 @@ class TestSubnet < Test::Unit::TestCase
     assert_instance_of(Yao::Resources::Network, subnet.network)
     assert_equal(subnet.network.id, "00000000-0000-0000-0000-000000000000")
   end
+
+  def test_tenant
+    stub_request(:get, "http://endpoint.example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "tenant": {
+            "id": "0123456789abcdef0123456789abcdef"
+          }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    subnet = Yao::Subnet.new('tenant_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Tenant, subnet.tenant)
+    assert_equal(subnet.tenant.id, '0123456789abcdef0123456789abcdef')
+  end
 end


### PR DESCRIPTION
Chao! Yao!



## What is This PR ?

Add method chain: `Yao::Port#tenant` that returns a `Yao::Tenant` instance of the port

## Before

Calling `Yao::Tenant.find` is a little cumbersome ...

```ruby
port   = Yao::Port.find(...)
tenant = Yao::Tenant.find(port.tenant_id)
```

## After

```ruby
tenant = Yao::Port.find(...).tenant 
```

#### Demo

```
yao(main):009:0> Yao::Port.find("006351bb-01c5-4755-bafd-8227372cd0f1").tenant
=> #<Yao::Resources::Tenant:0x00007fb81c648fa8 @data={"description"=>"", "enabled"=>true, "id"=>"bb09a61075f74ca08690721e425d5524", "name"=>"foobar"}>
```

## 📝 

`test/yao/resources/test_port.rb` was missing. So I also added tests of `friendly_attributes` and `map_attribute_to_attribute` in this PR 

## 日本語で ok

 * Yao::Port -> Yao::Tenant をメソッドチェインでひけるようにしたよ
 * Yao::Port のテストがそもそもなかったので、テスト足しておいたよ