### PR TITLE
テスト時のデバッグログを抑制する

### DIFF
--- a/test/yao/test_config.rb
+++ b/test/yao/test_config.rb
@@ -50,16 +50,29 @@ class TestConfig < Test::Unit::TestCase
     assert { hooked_value == "test 2" }
   end
 
-  def test_auth_is_hooked
-    auth = Yao::Auth
-    count = Yao::Config::HOOK_RENEW_CLIENT_KEYS.size
-    mock(auth).try_new.times(count)
-    Yao::Config::HOOK_RENEW_CLIENT_KEYS.each do |key|
-      Yao.configure do
-        set key, "http://dummy"
+  sub_test_case 'setting Yao.configure' do
+
+    def test_auth_is_hooked
+      auth = Yao::Auth
+      count = Yao::Config::HOOK_RENEW_CLIENT_KEYS.size
+      mock(auth).try_new.times(count)
+      Yao::Config::HOOK_RENEW_CLIENT_KEYS.each do |key|
+        # configurations have side effects !!!!
+        Yao.configure do
+          set key, "http://dummy"
+        end
       end
+
+      assert_received(auth) {|a| a.try_new.times(count) }
     end
 
-    assert_received(auth) {|a| a.try_new.times(count) }
+    # reset configurations of Yao.configure
+    def teardown
+      Yao::Config::HOOK_RENEW_CLIENT_KEYS.each do |key|
+        Yao.configure do
+          set key, nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi yao ! 

When I run the tests, I feel a bit annoying that `debug` and `debug_record_response` logging are flooded evertytime

<img width="991" alt="image" src="https://user-images.githubusercontent.com/172456/63679896-60862b80-c82d-11e9-9fca-d73bd9089a8c.png">

テストを走らせるたびに `debug` と `debug_record_response` のログがどば〜っと出て見にくいので直す PR です

# 原因

今回の変更を入れている Yao.configure のテストをした後に `debug`, `debug_record_response` が有効になったままになり 他のテストでデバッグログを出力する設定が有効になったままでした

副作用を持つテストですね

# 修正

問題となるテストを `sub_test_case` で分離して、 teardown で Yao.configure を nil で初期化しなおしてデバッグログが大量にでるのを解決しています