### PR TITLE
ハッシュの key が重複してwarning が出ているのを直す

### DIFF
--- a/test/yao/resources/test_loadbalancer_listener.rb
+++ b/test/yao/resources/test_loadbalancer_listener.rb
@@ -22,7 +22,6 @@ class TestLoadBalancerListener < Test::Unit::TestCase
       ],
       "l7policies" => [
           {
-              "id" => "58284ac9-673e-47ff-9dcb-09871a1956c4",
               "id" => "5e618272-339d-4a80-8d14-dbc093091bb1"
           }
       ],
@@ -49,7 +48,6 @@ class TestLoadBalancerListener < Test::Unit::TestCase
     ])
     assert_equal(listener.l7policies, [
         {
-            "id" => "58284ac9-673e-47ff-9dcb-09871a1956c4",
             "id" => "5e618272-339d-4a80-8d14-dbc093091bb1"
         }
     ])


### PR DESCRIPTION
## What does the PR fixes ? 

テストの中で、ハッシュのキー `id` が重複していて warning が出てしまっていたのを直す PR です

```
/path/to/test/yao/resources/test_loadbalancer_listener.rb:51: warning: key "id" is duplicated and overwritten on line 52
```

元々は @hiboma が入れ込んでしまったものでした.  sorry 🤕 