### PR TITLE
リファクタリング:   test/yao/resources/test_security_group_rule.rb  のクラス名を変更する

### DIFF
--- a/test/yao/resources/test_security_group_rule.rb
+++ b/test/yao/resources/test_security_group_rule.rb
@@ -1,4 +1,4 @@
-class TestSecurityGroup < Test::Unit::TestCase
+class TestSecurityGroupRule < Test::Unit::TestCase
   def test_rule_attributes
     params = {
       "id" => "test_rule_id_1",


### PR DESCRIPTION
*test/yao/resources/test_security_group_rule.rb* のクラス名が `TestSecurityGroup` と重複しているので修正する PR です

修正せずとも現状のテストの実行には問題はありませんが、クラス名が重複 -> 意図せずテストケースを上書きしてしまうような地雷を埋め込むのを避けられるかと思います 💣 