### PR TITLE
Add support Compute services (os-services)

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -28,6 +28,7 @@ module Yao
     autoload :RoleAssignment,            "yao/resources/role_assignment"
     autoload :Volume,                    "yao/resources/volume"
     autoload :VolumeType,                "yao/resources/volume_type"
+    autoload :ComputeServices,           "yao/resources/compute_services"
 
     autoload :Resource,                  "yao/resources/resource"
     autoload :Meter,                     "yao/resources/meter"

--- a/lib/yao/resources/compute_services.rb
+++ b/lib/yao/resources/compute_services.rb
@@ -1,0 +1,8 @@
+module Yao::Resources
+  class ComputeServices < Base
+    friendly_attributes  :status, :binary, :host, :zone, :state, :disabled_reason, :forced_down
+
+    self.service        = "compute"
+    self.resources_name = "os-services"
+  end
+end

--- a/lib/yao/resources/compute_services.rb
+++ b/lib/yao/resources/compute_services.rb
@@ -3,6 +3,40 @@ module Yao::Resources
     friendly_attributes  :status, :binary, :host, :zone, :state, :disabled_reason, :forced_down
 
     self.service        = "compute"
+    self.resource_name  = "service"
     self.resources_name = "os-services"
+
+    class << self
+      def enable(host, binary)
+        params = {
+          "host" => host,
+          "binary" => binary,
+        }
+        put("enable", params)
+      end
+
+      def disable(host, binary, reason = nil)
+        params = {
+          "host" => host,
+          "binary" => binary,
+        }
+        if reason
+          params["disabled_reason"] = reason
+          put("disable-log-reason", params)
+        else
+          put("disable", params)
+        end
+      end
+
+      private
+      def put(path, params)
+        res = PUT(create_url([api_version, resources_path, path]), params) do |req|
+          req.body = params.to_json
+          req.headers['Content-Type'] = 'application/json'
+        end
+        return_resource(resource_from_json(res.body))
+      end
+    end
+
   end
 end

--- a/test/yao/resources/test_compute_services.rb
+++ b/test/yao/resources/test_compute_services.rb
@@ -1,7 +1,4 @@
-class TestComputeServices < Test::Unit::TestCase
-  def setup
-    Yao.default_client.pool["compute"] = Yao::Client.gen_client("https://example.com:12345")
-  end
+class TestComputeServices < TestYaoResouce
 
   def test_compute_services
 

--- a/test/yao/resources/test_compute_services.rb
+++ b/test/yao/resources/test_compute_services.rb
@@ -1,0 +1,32 @@
+class TestComputeServices < Test::Unit::TestCase
+  def setup
+    Yao.default_client.pool["compute"] = Yao::Client.gen_client("https://example.com:12345")
+  end
+
+  def test_compute_services
+
+    # https://docs.openstack.org/api-ref/compute/?expanded=update-forced-down-detail,update-compute-service-detail,list-compute-services-detail#compute-services-os-services
+    params = {
+      "id" =>  1,
+      "binary" =>  "nova-scheduler",
+      "disabled_reason" =>  "test1",
+      "host" =>  "host1",
+      "state" =>  "up",
+      "status" =>  "disabled",
+      "updated_at" =>  "2012-10-29T13:42:02.000000",
+      "forced_down" =>  false,
+      "zone" =>  "internal"
+    }
+    compute_service = Yao::ComputeServices.new(params)
+
+    assert_equal(compute_service.id, 1)
+    assert_equal(compute_service.binary, "nova-scheduler")
+    assert_equal(compute_service.disabled_reason, "test1")
+    assert_equal(compute_service.host, "host1")
+    assert_equal(compute_service.state, "up")
+    assert_equal(compute_service.status, "disabled")
+    assert_equal(compute_service.updated, Time.mktime(2012,10,29,13,42,2))
+    assert_equal(compute_service.forced_down, false)
+    assert_equal(compute_service.zone, "internal")
+  end
+end

--- a/test/yao/resources/test_compute_services.rb
+++ b/test/yao/resources/test_compute_services.rb
@@ -29,4 +29,71 @@ class TestComputeServices < Test::Unit::TestCase
     assert_equal(compute_service.forced_down, false)
     assert_equal(compute_service.zone, "internal")
   end
+
+  def test_enable
+    stub = stub_request(:put, "https://example.com:12345/os-services/enable").
+      with(
+        body: <<~JSON.chomp
+        {"host":"host1","binary":"nova-compute"}
+        JSON
+      ).to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+            "service": {
+                "binary": "nova-compute",
+                "host": "host1",
+                "status": "enabled"
+            }
+        }
+        JSON
+      )
+
+    Yao::ComputeServices.enable('host1', 'nova-compute')
+    assert_requested stub
+  end
+
+  def test_disable
+    stub = stub_request(:put, "https://example.com:12345/os-services/disable").
+      with(
+        body: <<~JSON.chomp
+        {"host":"host1","binary":"nova-compute"}
+        JSON
+      ).to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "service": {
+          "binary": "nova-compute",
+          "host": "host1",
+          "status": "disabled"
+         }
+        }
+        JSON
+    )
+
+    Yao::ComputeServices.disable('host1', 'nova-compute')
+    assert_requested stub
+  end
+
+  def test_disable_with_reason
+    stub = stub_request(:put, "https://example.com:12345/os-services/disable-log-reason").
+      with(
+        body: <<~JSON.chomp
+        {"host":"host1","binary":"nova-compute","disabled_reason":"test2"}
+        JSON
+      ).to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+            "host": "host1",
+            "binary": "nova-compute",
+            "disabled_reason": "test2"
+        }
+        JSON
+    )
+
+    Yao::ComputeServices.disable('host1', 'nova-compute', 'test2')
+    assert_requested stub
+  end
 end

--- a/test/yao/resources/test_compute_services.rb
+++ b/test/yao/resources/test_compute_services.rb
@@ -47,9 +47,15 @@ class TestComputeServices < Test::Unit::TestCase
             }
         }
         JSON
+        headers: {'Content-Type' => 'application/json'}
       )
 
-    Yao::ComputeServices.enable('host1', 'nova-compute')
+    compute_service = Yao::ComputeServices.enable('host1', 'nova-compute')
+
+    assert_equal(compute_service.host, "host1")
+    assert_equal(compute_service.binary, "nova-compute")
+    assert_equal(compute_service.status, "enabled")
+
     assert_requested stub
   end
 
@@ -63,16 +69,22 @@ class TestComputeServices < Test::Unit::TestCase
         status: 200,
         body: <<-JSON,
         {
-          "service": {
-          "binary": "nova-compute",
-          "host": "host1",
-          "status": "disabled"
-         }
+            "service": {
+                "binary": "nova-compute",
+                "host": "host1",
+                "status": "disabled"
+           }
         }
         JSON
+        headers: {'Content-Type' => 'application/json'}
     )
 
-    Yao::ComputeServices.disable('host1', 'nova-compute')
+    compute_service = Yao::ComputeServices.disable('host1', 'nova-compute')
+
+    assert_equal(compute_service.host, "host1")
+    assert_equal(compute_service.binary, "nova-compute")
+    assert_equal(compute_service.status, "disabled")
+
     assert_requested stub
   end
 
@@ -86,14 +98,24 @@ class TestComputeServices < Test::Unit::TestCase
         status: 200,
         body: <<-JSON,
         {
-            "host": "host1",
-            "binary": "nova-compute",
-            "disabled_reason": "test2"
+            "service": {
+                "binary": "nova-compute",
+                "disabled_reason": "test2",
+                "host": "host1",
+                "status": "disabled"
+            }
         }
         JSON
+        headers: {'Content-Type' => 'application/json'}
     )
 
-    Yao::ComputeServices.disable('host1', 'nova-compute', 'test2')
+    compute_service = Yao::ComputeServices.disable('host1', 'nova-compute', 'test2')
+
+    assert_equal(compute_service.host, "host1")
+    assert_equal(compute_service.binary, "nova-compute")
+    assert_equal(compute_service.status, "disabled")
+    assert_equal(compute_service.disabled_reason, "test2")
+
     assert_requested stub
   end
 end


### PR DESCRIPTION
Added Nova API Compute service (os-services).
See below for details on the API.

https://docs.openstack.org/api-ref/compute/?expanded=update-compute-service-detail,list-compute-services-detail,disable-scheduling-for-a-compute-service-and-log-disabled-reason-detail,disable-scheduling-for-a-compute-service-detail,enable-scheduling-for-a-compute-service-detail#compute-services-os-services

