### PR TITLE
introduce Yao::Resources::NetworkAssociationable

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -2,6 +2,7 @@ module Yao
   module Resources
     require "yao/resources/base"
     require "yao/resources/tenant_associationable"
+    require "yao/resources/network_associationable"
 
     autoload :Server,                    "yao/resources/server"
     autoload :Flavor,                    "yao/resources/flavor"

--- a/lib/yao/resources/network_associationable.rb
+++ b/lib/yao/resources/network_associationable.rb
@@ -1,0 +1,14 @@
+module Yao
+  module Resources
+    module NetworkAssociationable
+
+      def self.included(base)
+        base.friendly_attributes :network_id
+      end
+
+      def network
+        @tenant ||= Yao::Network.find(network_id)
+      end
+    end
+  end
+end

--- a/lib/yao/resources/port.rb
+++ b/lib/yao/resources/port.rb
@@ -1,11 +1,12 @@
 module Yao::Resources
   class Port < Base
 
+    include NetworkAssociationable
     include TenantAssociationable
 
     friendly_attributes :name, :mac_address, :status, :allowed_address_pairs,
                         :device_owner, :fixed_ips, :security_groups, :device_id,
-                        :network_id, :admin_state_up
+                        :admin_state_up
     map_attribute_to_attribute "binding:host_id" => :host_id
 
     def primary_ip
@@ -14,10 +15,6 @@ module Yao::Resources
 
     def primary_subnet
       Yao::Subnet.find fixed_ips.first["subnet_id"]
-    end
-
-    def network
-      Yao::Network.find network_id
     end
 
     self.service        = "network"

--- a/lib/yao/resources/subnet.rb
+++ b/lib/yao/resources/subnet.rb
@@ -1,5 +1,7 @@
 module Yao::Resources
   class Subnet < Base
+
+    include NetworkAssociationable
     include TenantAssociationable
 
     friendly_attributes :name, :cidr, :gateway_ip, :network_id, :ip_version,
@@ -9,10 +11,6 @@ module Yao::Resources
       self["allocation_pools"].map do |pool|
         pool["start"]..pool["end"]
       end
-    end
-
-    def network
-      Yao::Network.find network_id
     end
 
     alias dhcp_enabled? enable_dhcp


### PR DESCRIPTION
Hi Yao!  This PR introduces `Yao::Resources::NetworkAssociationable`. 

`Yao::Resources::NetworkAssociationable` offers below functions

 * add friendly_attributes `network_id`
 * add method `network` to be relationable with Yao::Server

This PR derive from https://github.com/yaocloud/yao/pull/97

----

Yao::Resources::NetworkAssociationable というモジュールを導入して、 network_id と network を生やすようにする PR です. 

https://github.com/yaocloud/yao/pull/97 と同様に foobar_id からリソースを引く部分を module にしていくリファクタリングの PR です