### PR TITLE
Introduce Yao::Resources::PortAssociationable

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -2,6 +2,7 @@ module Yao
   module Resources
     require "yao/resources/base"
     require "yao/resources/tenant_associationable"
+    require "yao/resources/port_associationable"
 
     autoload :Server,                    "yao/resources/server"
     autoload :Flavor,                    "yao/resources/flavor"

--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -1,12 +1,13 @@
 module Yao::Resources
   class FloatingIP < Base
 
+    include PortAssociationable
     include TenantAssociationable
 
     friendly_attributes :router_id, :description, :dns_domain, :dns_name,
                         :revision_number,
                         :floating_network_id, :fixed_ip_address,
-                        :floating_ip_address, :port_id,
+                        :floating_ip_address,
                         :status, :port_details, :tags, :port_forwardings
 
     self.service        = "network"
@@ -21,9 +22,5 @@ module Yao::Resources
       @project ||= Yao::Tenant.get(project_id)
     end
     alias :tenant :project
-
-    def port
-      @port ||= Yao::Port.find(port_id)
-    end
   end
 end

--- a/lib/yao/resources/port_associationable.rb
+++ b/lib/yao/resources/port_associationable.rb
@@ -1,0 +1,14 @@
+module Yao
+  module Resources
+    module PortAssociationable
+
+      def self.included(base)
+        base.friendly_attributes :port_id
+      end
+
+      def port
+        @port ||= Yao::Port.find(port_id)
+      end
+    end
+  end
+end

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -117,9 +117,9 @@ class TestFloatingIP < Test::Unit::TestCase
         status: 200,
         body: <<-JSON,
         {
-          "ports": [{
+          "port": {
             "id": "0123456789abcdef0123456789abcdef"
-          }]
+          }
         }
         JSON
         headers: {'Content-Type' => 'application/json'}
@@ -127,5 +127,6 @@ class TestFloatingIP < Test::Unit::TestCase
 
     fip = Yao::FloatingIP.new("port_id" => "00000000-0000-0000-0000-000000000000")
     assert_instance_of(Yao::Port, fip.port)
+    assert_equal(fip.port.id, "0123456789abcdef0123456789abcdef")
   end
 end


### PR DESCRIPTION
Hi yao! 

This PR introduces `Yao::Resources::PortAssociationable` to rewrite ( refactoring)   the classes having `port_id` and `port` methods.

----

## notice

The PR derive from https://github.com/yaocloud/yao/pull/118