### PR TITLE
write more strict tests for Yao::Resoure::*

### DIFF
--- a/lib/yao/resources/port.rb
+++ b/lib/yao/resources/port.rb
@@ -13,11 +13,11 @@ module Yao::Resources
     end
 
     def primary_subnet
-      Yao::Subnet.find fixed_ips.first["subnet_id"]
+      @subnet ||= Yao::Subnet.find fixed_ips.first["subnet_id"]
     end
 
     def network
-      Yao::Network.find network_id
+      @network ||= Yao::Network.find network_id
     end
 
     self.service        = "network"

--- a/lib/yao/resources/subnet.rb
+++ b/lib/yao/resources/subnet.rb
@@ -12,7 +12,7 @@ module Yao::Resources
     end
 
     def network
-      Yao::Network.find network_id
+      @network ||= Yao::Network.find network_id
     end
 
     alias dhcp_enabled? enable_dhcp

--- a/test/yao/resources/test_flavor.rb
+++ b/test/yao/resources/test_flavor.rb
@@ -47,7 +47,7 @@ class TestFlavor < TestYaoResouce
   end
 
   def test_list_detail
-    stub_request(:get, "https://example.com:12345/flavors/detail").
+    stub = stub_request(:get, "https://example.com:12345/flavors/detail").
       to_return(
         status: 200,
         body: <<-JSON,
@@ -84,7 +84,9 @@ class TestFlavor < TestYaoResouce
       )
 
     flavors = Yao::Flavor.list_detail
-    assert { flavors.first.instance_of? Yao::Flavor }
+    assert_instance_of(Yao::Flavor, flavors.first)
     assert_equal(flavors.first.name, "m1.tiny")
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -61,26 +61,30 @@ class TestFloatingIP < TestYaoResouce
 
   def test_floating_ip_to_router
 
-    stub_request(:get, "https://example.com:12345/routers/00000000-0000-0000-0000-000000000000")
+    stub = stub_request(:get, "https://example.com:12345/routers/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
         {
-          "routers": [{
-            "id": "0123456789abcdef0123456789abcdef"
-          }]
+          "router": {
+            "id": "00000000-0000-0000-0000-000000000000"
+          }
         }
         JSON
         headers: {'Content-Type' => 'application/json'}
       )
 
     fip = Yao::FloatingIP.new("router_id" => "00000000-0000-0000-0000-000000000000")
+
     assert_instance_of(Yao::Router, fip.router)
+    assert_equal(fip.router.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 
   def test_tenant
 
-    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(
          status: 200,
          body: <<-JSON,
@@ -100,26 +104,31 @@ class TestFloatingIP < TestYaoResouce
 
     assert_instance_of(Yao::Tenant, fip.tenant)
     assert_instance_of(Yao::Tenant, fip.project)
-
     assert_equal(fip.tenant.id, '0123456789abcdef0123456789abcdef')
+
+    assert_requested(stub)
   end
 
   def test_floating_ip_to_port
 
-    stub_request(:get, "https://example.com:12345/ports/00000000-0000-0000-0000-000000000000")
+    stub = stub_request(:get, "https://example.com:12345/ports/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
         {
-          "ports": [{
-            "id": "0123456789abcdef0123456789abcdef"
-          }]
+          "port": {
+            "id": "00000000-0000-0000-0000-000000000000"
+          }
         }
         JSON
         headers: {'Content-Type' => 'application/json'}
       )
 
     fip = Yao::FloatingIP.new("port_id" => "00000000-0000-0000-0000-000000000000")
+
     assert_instance_of(Yao::Port, fip.port)
+    assert_equal(fip.port.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -10,7 +10,7 @@ class TestHypervisor < TestYaoResouce
   end
 
   def test_list_detail
-    stub_request(:get, "https://example.com:12345/os-hypervisors/detail")
+    stub = stub_request(:get, "https://example.com:12345/os-hypervisors/detail")
       .with(headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>"Faraday v#{Faraday::VERSION}"})
       .to_return(
         status: 200,
@@ -26,10 +26,12 @@ class TestHypervisor < TestYaoResouce
 
     h = Yao::Resources::Hypervisor.list_detail
     assert_equal(h.first.id, "dummy")
+
+    assert_requested(stub)
   end
 
   def test_statistics
-    stub_request(:get, "https://example.com:12345/os-hypervisors/statistics")
+    stub = stub_request(:get, "https://example.com:12345/os-hypervisors/statistics")
       .with(headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>"Faraday v#{Faraday::VERSION}"})
       .to_return(
         status: 200,
@@ -56,10 +58,12 @@ class TestHypervisor < TestYaoResouce
 
     s = Yao::Resources::Hypervisor.statistics
     assert_equal(s.count, 1)
+
+    assert_requested(stub)
   end
 
   def test_uptime
-    stub_request(:get, "https://example.com:12345/os-hypervisors/1/uptime")
+    stub = stub_request(:get, "https://example.com:12345/os-hypervisors/1/uptime")
       .with(headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>"Faraday v#{Faraday::VERSION}"})
       .to_return(
         status: 200,
@@ -79,5 +83,7 @@ class TestHypervisor < TestYaoResouce
 
     u = Yao::Resources::Hypervisor.uptime(1)
     assert_equal(u.uptime, " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14")
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_keypair.rb
+++ b/test/yao/resources/test_keypair.rb
@@ -20,7 +20,7 @@ EOS
   end
 
   def test_list
-    stub_request(:get, "https://example.com:12345/os-keypairs")
+    stub = stub_request(:get, "https://example.com:12345/os-keypairs")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -46,5 +46,6 @@ EOS
 
     keypairs = Yao::Keypair.list
     assert_equal(keypairs.first.fingerprint, "7e:eb:ab:24:ba:d1:e1:88:ae:9a:fb:66:53:df:d3:bd")
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_meter.rb
+++ b/test/yao/resources/test_meter.rb
@@ -28,9 +28,8 @@ class TestMeter < TestYaoResouce
   end
 
   def test_resource
-
     # https://docs.openstack.org/ceilometer/pike/webapi/v2.html
-    stub_request(:get, "https://example.com:12345/v2/resources/00000000-0000-0000-0000-000000000000")
+    stub = stub_request(:get, "https://example.com:12345/v2/resources/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -46,13 +45,15 @@ class TestMeter < TestYaoResouce
     }
 
     meter    = Yao::Meter.new(params)
-    resource = meter.resource
-    assert_instance_of(Yao::Resource, resource)
-    assert_equal(resource.resource_id, "00000000-0000-0000-0000-000000000000")
+    assert_instance_of(Yao::Resource, meter.resource)
+    assert_equal(meter.resource.resource_id, "00000000-0000-0000-0000-000000000000")
+    assert_equal(meter.resource.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 
   def test_tenant
-    stub_request(:get, "https://example.com:12345/tenants/00000000-0000-0000-0000-000000000000")
+    stub = stub_request(:get, "https://example.com:12345/tenants/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -72,10 +73,12 @@ class TestMeter < TestYaoResouce
     meter  = Yao::Meter.new(params)
     assert_instance_of(Yao::Tenant, meter.tenant)
     assert_equal(meter.tenant.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 
   def test_user
-    stub_request(:get, "https://example.com:12345/users/00000000-0000-0000-0000-000000000000")
+    stub = stub_request(:get, "https://example.com:12345/users/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -95,5 +98,7 @@ class TestMeter < TestYaoResouce
     meter  = Yao::Meter.new(params)
     assert_instance_of(Yao::User, meter.user)
     assert_equal(meter.user.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_network.rb
+++ b/test/yao/resources/test_network.rb
@@ -38,7 +38,7 @@ class TestNetwork < TestYaoResouce
 
   def test_tenant
 
-    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(
          status: 200,
          body: <<-JSON,
@@ -58,7 +58,8 @@ class TestNetwork < TestYaoResouce
 
     assert_instance_of(Yao::Tenant, network.tenant)
     assert_instance_of(Yao::Tenant, network.project)
-
     assert_equal(network.tenant.id, '0123456789abcdef0123456789abcdef')
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -79,7 +79,7 @@ class TestPort < TestYaoResouce
 
   def test_tenant
 
-    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -95,6 +95,8 @@ class TestPort < TestYaoResouce
     port = Yao::Port.new('tenant_id' => '0123456789abcdef0123456789abcdef')
     assert_instance_of(Yao::Tenant, port.tenant)
     assert_equal(port.tenant.id, '0123456789abcdef0123456789abcdef')
+
+    assert_requested(stub)
   end
 
   def test_primary_ip
@@ -114,7 +116,7 @@ class TestPort < TestYaoResouce
 
   def test_primary_subnet
 
-    stub_request(:get, "https://example.com:12345/subnets/00000000-0000-0000-0000-000000000000")
+    stub = stub_request(:get, "https://example.com:12345/subnets/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -139,11 +141,13 @@ class TestPort < TestYaoResouce
     port = Yao::Port.new(params)
     assert{ port.primary_subnet.instance_of?(Yao::Subnet) }
     assert_equal(port.primary_subnet.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 
   def test_network
 
-    stub_request(:get, "https://example.com:12345/networks/00000000-0000-0000-0000-000000000000")
+    stub = stub_request(:get, "https://example.com:12345/networks/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -163,5 +167,7 @@ class TestPort < TestYaoResouce
     port = Yao::Port.new(params)
     assert_instance_of(Yao::Network, port.network)
     assert_equal(port.network.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_role_assignment.rb
+++ b/test/yao/resources/test_role_assignment.rb
@@ -33,7 +33,7 @@ class TestRoleAssignment < TestYaoResouce
   end
 
   def test_project
-    stub_request(:get, "http://example.com:12345/tenants/456789").
+    stub = stub_request(:get, "http://example.com:12345/tenants/456789").
       to_return(
         status: 200,
         body: <<-JSON,
@@ -57,5 +57,7 @@ class TestRoleAssignment < TestYaoResouce
     role_assignment = Yao::RoleAssignment.new(params)
     assert_instance_of(Yao::Resources::Tenant, role_assignment.project)
     assert_equal(role_assignment.project.id, "456789")
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_router.rb
+++ b/test/yao/resources/test_router.rb
@@ -104,7 +104,7 @@ class TestRouter < TestYaoResouce
   end
 
   def test_iterfaces
-    stub_request(:get, "https://example.com:12345/ports?device_id=00000000-0000-0000-0000-000000000000")
+    stub = stub_request(:get, "https://example.com:12345/ports?device_id=00000000-0000-0000-0000-000000000000")
     .to_return(
         status: 200,
         body: <<-JSON,
@@ -125,11 +125,13 @@ class TestRouter < TestYaoResouce
     port   = router.interfaces.first
     assert_instance_of(Yao::Port, port)
     assert_equal(port.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 
   def test_tenant
 
-    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -145,5 +147,7 @@ class TestRouter < TestYaoResouce
     router = Yao::Router.new('tenant_id' => '0123456789abcdef0123456789abcdef')
     assert_instance_of(Yao::Tenant, router.tenant)
     assert_equal(router.tenant.id, '0123456789abcdef0123456789abcdef')
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_security_group.rb
+++ b/test/yao/resources/test_security_group.rb
@@ -25,7 +25,7 @@ class TestSecurityGroup < TestYaoResouce
 
   def test_sg_to_tenant
 
-    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -41,5 +41,7 @@ class TestSecurityGroup < TestYaoResouce
     sg = Yao::SecurityGroup.new('tenant_id' => '0123456789abcdef0123456789abcdef')
     assert_instance_of(Yao::Tenant, sg.tenant)
     assert_equal(sg.tenant.id, '0123456789abcdef0123456789abcdef')
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -139,7 +139,7 @@ class TestServer < TestYaoResouce
   end
 
   def test_list_detail
-    stub_request(:get, "https://example.com:12345/servers/detail")
+    stub = stub_request(:get, "https://example.com:12345/servers/detail")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -156,11 +156,13 @@ class TestServer < TestYaoResouce
     assert_instance_of(Array, servers)
     assert_instance_of(Yao::Server, servers.first)
     assert_equal(servers.first.id, 'dummy')
+
+    assert_requested(stub)
   end
 
   def test_tenant
 
-    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -176,5 +178,7 @@ class TestServer < TestYaoResouce
     server = Yao::Server.new('tenant_id' => '0123456789abcdef0123456789abcdef')
     assert_instance_of(Yao::Tenant, server.tenant)
     assert_equal(server.tenant.id, '0123456789abcdef0123456789abcdef')
+
+    assert_requested(stub)
   end
 end

--- a/test/yao/resources/test_subnet.rb
+++ b/test/yao/resources/test_subnet.rb
@@ -52,7 +52,7 @@ class TestSubnet < TestYaoResouce
   end
 
   def test_network
-    stub_request(:get, "https://example.com:12345/networks/00000000-0000-0000-0000-000000000000").
+    stub = stub_request(:get, "https://example.com:12345/networks/00000000-0000-0000-0000-000000000000").
       to_return(
        status: 200,
        body: <<-JSON,
@@ -72,10 +72,12 @@ class TestSubnet < TestYaoResouce
     subnet = Yao::Subnet.new(params)
     assert_instance_of(Yao::Resources::Network, subnet.network)
     assert_equal(subnet.network.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
   end
 
   def test_tenant
-    stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
@@ -91,5 +93,7 @@ class TestSubnet < TestYaoResouce
     subnet = Yao::Subnet.new('tenant_id' => '0123456789abcdef0123456789abcdef')
     assert_instance_of(Yao::Tenant, subnet.tenant)
     assert_equal(subnet.tenant.id, '0123456789abcdef0123456789abcdef')
+
+    assert_requested(stub)
   end
 end


### PR DESCRIPTION
Hi Yao! 

## use assert_requested ! 

I added  `assert_requested` tests for Yao::Resoure::*  to more strictly check whether `stub_request` are requested actually. 

And I found some tests are broken  ( ... these tests were written by me originally  🤕  ) and some attributes behavior are inconsistent with others. I also fixed these problemes. 

----

* `stub_request` で生成した stub が実際にリクエストされたかどうかを ` assert_requested`  で厳密にテストするようにしました。
  *  とあるテストで生成した `stub_request` が、うっかり別のテストに副作用を出していないことを保証できます
* そんでもって書き直しているうちにテストが壊れているのと attrbitute から resource を生成するメソッドでキャッシュが効いてないリソースを直しておきました ( ... そもそも私が書いたものでした）
