### PR TITLE
Drop support ruby-2.3

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.6.x', '2.5.x', '2.4.x', '2.3.x' ]
+        ruby: [ '2.6.x', '2.5.x', '2.4.x' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby


### PR DESCRIPTION
CIでruby-2.3を回すのをやめます。
ruby-2.3はEOLになっています。
https://www.ruby-lang.org/ja/news/2019/03/31/support-of-ruby-2-3-has-ended/