### PR TITLE
Deprecate Yao::Resources::RestfullyAccessible.return_resource

### DIFF
--- a/lib/yao/resources/action.rb
+++ b/lib/yao/resources/action.rb
@@ -5,7 +5,7 @@ module Yao::Resources
         req.body = query.to_json
         req.headers['Content-Type'] = 'application/json'
       end
-      res.body ? return_resource(resource_from_json(res.body)) : nil
+      res.body ? resource_from_json(res.body) : nil
     end
 
     private

--- a/lib/yao/resources/compute_services.rb
+++ b/lib/yao/resources/compute_services.rb
@@ -38,7 +38,7 @@ module Yao::Resources
           req.body = params.to_json
           req.headers['Content-Type'] = 'application/json'
         end
-        return_resource(resource_from_json(res.body))
+        resource_from_json(res.body)
       end
     end
 

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -32,11 +32,14 @@ module Yao::Resources
         )
       end
 
+      # @return [Yao::Resources::Hypervisor::Statistics]
       def statistics
         json = GET([resources_path, "statistics"].join("/")).body
         Yao::Resources::Hypervisor::Statistics.new(json["hypervisor_statistics"])
       end
 
+      # @param id [String]
+      # @return [Yao::Resources::Hypervisor::Uptime]
       def uptime(id)
         json = GET([resources_path, id, "uptime"].join("/")).body
         Yao::Resources::Hypervisor::Uptime.new(json["hypervisor"])

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -38,10 +38,8 @@ module Yao::Resources
       end
 
       def uptime(id)
-        res = resource_from_json(
-                GET([resources_path, id, "uptime"].join("/")).body
-              )
-        Yao::Resources::Hypervisor::Uptime.new(res)
+        json = GET([resources_path, id, "uptime"].join("/")).body
+        Yao::Resources::Hypervisor::Uptime.new(json["hypervisor"])
       end
     end
 

--- a/lib/yao/resources/keypair.rb
+++ b/lib/yao/resources/keypair.rb
@@ -6,10 +6,29 @@ module Yao::Resources
     self.resource_name  = "os-keypair"
     self.resources_name = "os-keypairs"
 
+    # os-keypairs API returns very complicated JSON.
+    # For example.
+    # {
+    #   "keypairs": [
+    #     {
+    #       "keypair": {
+    #          "fingerprint": "...",
+    #        }
+    #     },
+    #     {
+    #       "keypair": {
+    #          "fingerprint": "...",
+    #        }
+    #     },
+    #   ]
+    #
+    # @param query [Hash]
+    # @return [Array<Yao::Resources::Keypairs>]
     def self.list(query={})
-      return_resources(
-        resources_from_json(GET(resources_name, query).body).map{|r| resource_from_json(r)}
-      )
+      res = GET(resources_name, query)
+      res.body['keypairs'].map { |attribute|
+        new(attribute['keypair'])
+      }
     end
   end
 end

--- a/lib/yao/resources/meter.rb
+++ b/lib/yao/resources/meter.rb
@@ -24,11 +24,11 @@ module Yao::Resources
     class << self
       private
       def resource_from_json(json)
-        json
+        new(json)
       end
 
       def resources_from_json(json)
-        json
+        new(json)
       end
     end
   end

--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -30,7 +30,7 @@ module Yao::Resources
     def self.list(meter_name, query={})
       cache_key = [meter_name, *query].join
       cache[cache_key] = GET("#{self.api_version}/meters/#{meter_name}", query).body unless cache[cache_key]
-      return_resources(cache[cache_key])
+      new(cache[cache_key])
     end
 
     def self.cache

--- a/lib/yao/resources/resource.rb
+++ b/lib/yao/resources/resource.rb
@@ -48,7 +48,7 @@ module Yao::Resources
         new(json)
       end
 
-      # override Yao::Resources::RestfullyAccessible.resource_from_json
+      # override Yao::Resources::RestfullyAccessible.resources_from_json
       # @param [Hash]
       # @return [Yao::Resources::Resource]
       def resources_from_json(json)

--- a/lib/yao/resources/resource.rb
+++ b/lib/yao/resources/resource.rb
@@ -40,10 +40,17 @@ module Yao::Resources
 
     class << self
       private
+
+      # override Yao::Resources::RestfullyAccessible.resource_from_json
+      # @param [Hash]
+      # @return [Yao::Resources::Resource]
       def resource_from_json(json)
         new(json)
       end
 
+      # override Yao::Resources::RestfullyAccessible.resource_from_json
+      # @param [Hash]
+      # @return [Yao::Resources::Resource]
       def resources_from_json(json)
         new(json)
       end

--- a/lib/yao/resources/resource.rb
+++ b/lib/yao/resources/resource.rb
@@ -41,11 +41,11 @@ module Yao::Resources
     class << self
       private
       def resource_from_json(json)
-        json
+        new(json)
       end
 
       def resources_from_json(json)
-        json
+        new(json)
       end
     end
   end

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -84,7 +84,7 @@ module Yao::Resources
     def list(query={})
       json = GET(create_url, query).body
       if return_single_on_querying && !query.empty?
-        return_resource(resource_from_json(json))
+        resource_from_json(json)
       else
         return_resources(resources_from_json(json))
       end
@@ -102,7 +102,7 @@ module Yao::Resources
               get_by_name(id_or_name_or_permalink, query)
             end
 
-      return_resource(resource_from_json(res.body))
+      resource_from_json(res.body)
     end
     alias find get
 
@@ -120,7 +120,7 @@ module Yao::Resources
         req.body = params.to_json
         req.headers['Content-Type'] = 'application/json'
       end
-      return_resource(resource_from_json(res.body))
+      resource_from_json(res.body)
     end
 
     # @param id [String]
@@ -133,7 +133,7 @@ module Yao::Resources
         req.body = params.to_json
         req.headers['Content-Type'] = 'application/json'
       end
-      return_resource(resource_from_json(res.body))
+      resource_from_json(res.body)
     end
 
     # @param id [String]
@@ -153,25 +153,29 @@ module Yao::Resources
       paths.select{|s| s != ''}.join('/')
     end
 
+    # @return [String]
     def resource_name_in_json
       @_resource_name_in_json ||= resource_name.sub(/^os-/, "").tr("-", "_")
     end
 
+    # @param json [Hash]
+    # @return [Yao::Resources::*]
     def resource_from_json(json)
-      json[resource_name_in_json]
+      attribute = json[resource_name_in_json]
+      new(attribute)
     end
 
+    # @param json [Hash]
+    # @return [Array<Hash>]
     def resources_from_json(json)
       @resources_name_in_json ||= resources_name.sub(/^os-/, "").tr("-", "_")
       json[@resources_name_in_json]
     end
 
-    def return_resource(d)
-      new(d)
-    end
-
+    # @param arr [Array<Hash>]
+    # @return [Array<Yao::Resources::*>]
     def return_resources(arr)
-      arr.map{|d| return_resource(d) }
+      arr.map{|d| new(d) }
     end
 
     def uuid?(str)


### PR DESCRIPTION
This PR depcates `Yao::Resources::RestfullyAccessible.return_resource`. 

##  Yao::Resources::RestfullyAccessible.return_resource を廃止することを提案する PR です

### 1. コードを読む際の複雑さの解消

 `return_resource` と  `resource_from_json` をネストして呼び出す API をとっているが、`resource_from_json` のみで表現可能であること

### 2. 結合度を下げる

Yao::Resourece::* の一部のクラスでは OpenStack の API が返すデータ構造の不均一を吸収するために  Yao::Resources::RestfullyAccessible` のメソッドをオーバライドしている.

オーバライドする際に  `return_resourece` を用いているモジュールもあるが、 private method として設計されたメソッドがモジュール外に散逸するのは好ましくないと考えます ( private method の露出を下げた方がモジュールの結合度を低くおさえられる ) 

### 3. 命名とインタフェースの不一致を解決する

 `return_resource` が `Yao::Resources::*` のインスタンスを返す一方で、`resource_from_json` は Hash を返すという `resource` という命名に対するインタフェースの不一致を解消します
 
----

というのが諸々の理由です!!