### PR TITLE
Deprecate Yao::Resources::RestfullyAccessible.return_resources, Yao::Resources::*.list_detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Yao.configure do
 end
 
 Yao::Network.list # list up networks...
-Yao::Server.list_detail # list up instances...
+Yao::Server.list # list up instances...
 ```
 
 If you want to override some of endpoints by service, you can do:
@@ -79,7 +79,7 @@ OpenStack.configure do
   password    "tonk0tsu-r@men"
 end
 
-OpenStack::Server.list_detail # And let's go on
+OpenStack::Server.list # And let's go on
 ```
 
 ## Contributing

--- a/lib/yao/resources/flavor.rb
+++ b/lib/yao/resources/flavor.rb
@@ -19,12 +19,12 @@ module Yao::Resources
     self.resources_name = "flavors"
 
     class << self
+
+      # @param query [Hash]
+      # @return [Array<Yao::Resources::Flavor>]
       def list_detail(query={})
-        return_resources(
-          resources_from_json(
-            GET([resources_path, "detail"].join("/"), query).body
-          )
-        )
+        res = GET([resources_path, "detail"].join("/"), query)
+        resources_from_json(res.body)
       end
     end
   end

--- a/lib/yao/resources/flavor.rb
+++ b/lib/yao/resources/flavor.rb
@@ -17,15 +17,6 @@ module Yao::Resources
     self.service        = "compute"
     self.resource_name  = "flavor"
     self.resources_name = "flavors"
-
-    class << self
-
-      # @param query [Hash]
-      # @return [Array<Yao::Resources::Flavor>]
-      def list_detail(query={})
-        res = GET([resources_path, "detail"].join("/"), query)
-        resources_from_json(res.body)
-      end
-    end
+    self.resources_detail_available = true
   end
 end

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -22,16 +22,9 @@ module Yao::Resources
     self.service        = "compute"
     self.resource_name  = "os-hypervisor"
     self.resources_name = "os-hypervisors"
+    self.resources_detail_available = true
 
     class << self
-
-      # @param query [Hash]
-      # @return [Array<Yao::Resources::Hypervisor>]
-      def list_detail(query={})
-        res = GET([resources_path, "detail"].join("/"), query)
-        resources_from_json(res.body)
-      end
-
       # @return [Yao::Resources::Hypervisor::Statistics]
       def statistics
         json = GET([resources_path, "statistics"].join("/")).body

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -24,12 +24,12 @@ module Yao::Resources
     self.resources_name = "os-hypervisors"
 
     class << self
+
+      # @param query [Hash]
+      # @return [Array<Yao::Resources::Hypervisor>]
       def list_detail(query={})
-        return_resources(
-          resources_from_json(
-            GET([resources_path, "detail"].join("/"), query).body
-          )
-        )
+        res = GET([resources_path, "detail"].join("/"), query)
+        resources_from_json(res.body)
       end
 
       # @return [Yao::Resources::Hypervisor::Statistics]

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -105,6 +105,9 @@ module Yao::Resources
       end
     end
 
+    # @note .list is defined to keep backward compatibility and will be deprecated
+    alias :list_detail :list
+
     # @param id_or_name_or_permalink [Stirng]
     # @param query [Hash]
     # @return [Yao::Resources::*]

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -84,9 +84,11 @@ module Yao::Resources
     def list(query={})
       json = GET(create_url, query).body
       if return_single_on_querying && !query.empty?
+        # returns Yao::Resources::*
         resource_from_json(json)
       else
-        return_resources(resources_from_json(json))
+        # returns Array of Yao::Resources::*
+        resources_from_json(json)
       end
     end
 
@@ -158,6 +160,11 @@ module Yao::Resources
       @_resource_name_in_json ||= resource_name.sub(/^os-/, "").tr("-", "_")
     end
 
+    # @return [String]
+    def resources_name_in_json
+      @resources_name_in_json ||= resources_name.sub(/^os-/, "").tr("-", "_")
+    end
+
     # @param json [Hash]
     # @return [Yao::Resources::*]
     def resource_from_json(json)
@@ -166,16 +173,11 @@ module Yao::Resources
     end
 
     # @param json [Hash]
-    # @return [Array<Hash>]
-    def resources_from_json(json)
-      @resources_name_in_json ||= resources_name.sub(/^os-/, "").tr("-", "_")
-      json[@resources_name_in_json]
-    end
-
-    # @param arr [Array<Hash>]
     # @return [Array<Yao::Resources::*>]
-    def return_resources(arr)
-      arr.map{|d| new(d) }
+    def resources_from_json(json)
+      json[resources_name_in_json].map { |attribute|
+        new(attribute) # instance of Yao::Resources::*
+      }
     end
 
     def uuid?(str)

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -5,7 +5,7 @@ module Yao::Resources
     def self.extended(base)
       base.class_eval do
         class << self
-          attr_accessor :resource_name, :resources_name
+          attr_accessor :resource_name, :resources_name, :resources_detail_available
 
           extend Forwardable
           %w(get post put delete).each do |method_name|
@@ -82,7 +82,20 @@ module Yao::Resources
     # @return [Yao::Resources::*]
     # @return [Array<Yao::Resources::*]
     def list(query={})
-      json = GET(create_url, query).body
+
+      url = if resources_detail_available
+        # If the resource has 'detail', #list tries to GET /${resourece}/detail
+        # For example.
+        #
+        #   GET /servers/detail
+        #   GET /flavors/detail
+        #
+        create_url('detail')
+      else
+        create_url
+      end
+
+      json = GET(url, query).body
       if return_single_on_querying && !query.empty?
         # returns Yao::Resources::*
         resource_from_json(json)

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -55,12 +55,11 @@ module Yao::Resources
     class << self
       alias :stop :shutoff
 
+      # @param query [Hash]
+      # @return [Array<Yao::Resources::Server>]
       def list_detail(query={})
-        return_resources(
-          resources_from_json(
-            GET([resources_path, "detail"].join("/"), query).body
-          )
-        )
+        res = GET([resources_path, "detail"].join("/"), query)
+        resources_from_json(res.body)
       end
     end
 

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -23,6 +23,7 @@ module Yao::Resources
     self.service        = "compute"
     self.resource_name  = "server"
     self.resources_name = "servers"
+    self.resources_detail_available = true
 
     def old_samples(counter_name: nil, query: {})
       Yao::OldSample.list(counter_name, query).select{|os| os.resource_metadata["instance_id"] == id}
@@ -54,13 +55,6 @@ module Yao::Resources
 
     class << self
       alias :stop :shutoff
-
-      # @param query [Hash]
-      # @return [Array<Yao::Resources::Server>]
-      def list_detail(query={})
-        res = GET([resources_path, "detail"].join("/"), query)
-        resources_from_json(res.body)
-      end
     end
 
     extend MetadataAvailable

--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -9,7 +9,7 @@ module Yao::Resources
     self.return_single_on_querying = true
 
     def servers
-      @servers ||= Yao::Server.list_detail(all_tenants: 1).select{|s| s.tenant_id == id }
+      @servers ||= Yao::Server.list(all_tenants: 1).select{|s| s.tenant_id == id }
     end
 
     def meters

--- a/lib/yao/resources/volume.rb
+++ b/lib/yao/resources/volume.rb
@@ -9,12 +9,12 @@ module Yao::Resources
     self.resources_name = "volumes"
 
     class << self
+
+      # @param query [Hash]
+      # @return [Array<Yao::Resources::Volume]
       def list_detail(query={})
-        return_resources(
-            resources_from_json(
-                GET([resources_path, "detail"].join("/"), query).body
-            )
-        )
+        res = GET([resources_path, "detail"].join("/"), query)
+        resources_from_json(res.body)
       end
     end
   end

--- a/lib/yao/resources/volume.rb
+++ b/lib/yao/resources/volume.rb
@@ -7,15 +7,6 @@ module Yao::Resources
     self.service        = "volumev3"
     self.resource_name  = "volume"
     self.resources_name = "volumes"
-
-    class << self
-
-      # @param query [Hash]
-      # @return [Array<Yao::Resources::Volume]
-      def list_detail(query={})
-        res = GET([resources_path, "detail"].join("/"), query)
-        resources_from_json(res.body)
-      end
-    end
+    self.resources_detail_available = true
   end
 end

--- a/test/support/test_yao_resource.rb
+++ b/test/support/test_yao_resource.rb
@@ -29,6 +29,7 @@ class TestYaoResource < Test::Unit::TestCase
     Yao.default_client.pool["network"]        = client
     Yao.default_client.pool["compute"]        = client
     Yao.default_client.pool["metering"]       = client
+    Yao.default_client.pool["volumev3"]       = client
   end
 
   # 他のテストで副作用を出さないように Yao::Client.default_client, Yao::Conig を nil でリセットしておきます

--- a/test/yao/resources/test_flavor.rb
+++ b/test/yao/resources/test_flavor.rb
@@ -46,7 +46,7 @@ class TestFlavor < TestYaoResource
     assert_equal(flavor.memory, 512)
   end
 
-  def test_list_detail
+  def test_list
     stub = stub_request(:get, "https://example.com:12345/flavors/detail").
       to_return(
         status: 200,
@@ -83,7 +83,7 @@ class TestFlavor < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
-    flavors = Yao::Flavor.list_detail
+    flavors = Yao::Flavor.list
     assert_instance_of(Yao::Flavor, flavors.first)
     assert_equal(flavors.first.name, "m1.tiny")
 

--- a/test/yao/resources/test_flavor.rb
+++ b/test/yao/resources/test_flavor.rb
@@ -91,4 +91,10 @@ class TestFlavor < TestYaoResource
 
     assert_requested(stub)
   end
+
+  def test_list_detail
+    # Yao::Flavor.list_detail と Yao::Flavor.list が alias にあることをテストする
+    # see also: https://stackoverflow.com/questions/25883618/how-to-test-method-alias-ruby
+    assert_equal(Yao::Flavor.method(:list_detail), Yao::Flavor.method(:list))
+  end
 end

--- a/test/yao/resources/test_flavor.rb
+++ b/test/yao/resources/test_flavor.rb
@@ -83,6 +83,8 @@ class TestFlavor < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
+    assert(Yao::Flavor.resources_detail_available)
+
     flavors = Yao::Flavor.list
     assert_instance_of(Yao::Flavor, flavors.first)
     assert_equal(flavors.first.name, "m1.tiny")

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -30,6 +30,10 @@ class TestHypervisor < TestYaoResource
     assert_requested(stub)
   end
 
+  def test_list_detail
+    assert_equal(Yao::Hypervisor.method(:list_detail), Yao::Hypervisor.method(:list))
+  end
+
   def test_statistics
     stub = stub_request(:get, "https://example.com:12345/os-hypervisors/statistics")
       .with(headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>"Faraday v#{Faraday::VERSION}"})

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -9,7 +9,7 @@ class TestHypervisor < TestYaoResource
     assert_equal(host.enabled?, true)
   end
 
-  def test_list_detail
+  def test_list
     stub = stub_request(:get, "https://example.com:12345/os-hypervisors/detail")
       .with(headers: {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>"Faraday v#{Faraday::VERSION}"})
       .to_return(
@@ -24,7 +24,7 @@ class TestHypervisor < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
-    h = Yao::Resources::Hypervisor.list_detail
+    h = Yao::Resources::Hypervisor.list
     assert_equal(h.first.id, "dummy")
 
     assert_requested(stub)

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -138,7 +138,7 @@ class TestServer < TestYaoResource
     assert_equal(server.ext_sts_vm_state, "active")
   end
 
-  def test_list_detail
+  def test_list
     stub = stub_request(:get, "https://example.com:12345/servers/detail")
       .to_return(
         status: 200,
@@ -152,7 +152,7 @@ class TestServer < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
-    servers = Yao::Server.list_detail
+    servers = Yao::Server.list
     assert_instance_of(Array, servers)
     assert_instance_of(Yao::Server, servers.first)
     assert_equal(servers.first.id, 'dummy')

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -162,6 +162,10 @@ class TestServer < TestYaoResource
     assert_requested(stub)
   end
 
+  def test_list_detail
+    assert_equal(Yao::Server.method(:list_detail), Yao::Server.method(:list))
+  end
+
   def test_tenant
 
     stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -152,6 +152,8 @@ class TestServer < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
+    assert(Yao::Server.resources_detail_available)
+
     servers = Yao::Server.list
     assert_instance_of(Array, servers)
     assert_instance_of(Yao::Server, servers.first)

--- a/test/yao/resources/test_volume.rb
+++ b/test/yao/resources/test_volume.rb
@@ -35,4 +35,8 @@ class TestVolume < TestYaoResource
 
     assert_requested(stub)
   end
+
+  def test_list_detail
+    assert_equal(Yao::Volume.method(:list_detail), Yao::Volume.method(:list))
+  end
 end

--- a/test/yao/resources/test_volume.rb
+++ b/test/yao/resources/test_volume.rb
@@ -9,4 +9,30 @@ class TestVolume < TestYaoResource
     assert_equal('cinder', volume.name)
     assert_equal(10, volume.size)
   end
+
+  def test_list
+    # https://docs.openstack.org/api-ref/block-storage/v3/index.html?expanded=#volumes-volumes
+    stub = stub_request(:get, "https://example.com:12345/volumes/detail").
+      to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+            "volumes": [
+                {
+                    "id": "00000000-0000-0000-0000-000000000000"
+                }
+            ]
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    assert(Yao::Volume.resources_detail_available)
+
+    volumes = Yao::Volume.list
+    assert_instance_of(Yao::Volume, volumes.first)
+    assert_equal(volumes.first.id, "00000000-0000-0000-0000-000000000000")
+
+    assert_requested(stub)
+  end
 end


### PR DESCRIPTION
Hi. This PR depcates `Yao::Resources::RestfullyAccessible.return_resources` same as https://github.com/yaocloud/yao/pull/126. 

`Yao::Resources::RestfullyAccessible.return_resources` を廃止することを提案する PR です

## Draft PR で 相談したいこと

`return_resources` を消していく中で、特定のリソースで `list_detail` の実装がコピペ状態になっているのを見つけました

```ruby
      # @param query [Hash]
      # @return [Array<Yao::Resources::*>]
      def list_detail(query={})
        res = GET([resources_path, "detail"].join("/"), query)
        resources_from_json(res.body)
      end
```

この  `list_detail` の実装を `Yao::Resources::*` から `Yao::Resources::RestfullyAccessible` に集約するとでコードが DRY になるだろうと考えています

#### 迷っていること

上記のような変更を入れると、 OpenStack API で `/${resource_path}/details` を持たない リソースにも  `list_detail` が生えてしまうので どのように集約するのがいいかなぁと思案しています
