### PR TITLE
add syntax sugar methods: Yao::ComputeServices#enabled?, Yao::ComputeServices#disabled?

### DIFF
--- a/lib/yao/resources/compute_services.rb
+++ b/lib/yao/resources/compute_services.rb
@@ -6,6 +6,18 @@ module Yao::Resources
     self.resource_name  = "service"
     self.resources_name = "os-services"
 
+    # return true if ComputeServices is enabled
+    # @return [Bool]
+    def enabled?
+      status == 'enabled'
+    end
+
+    # return true if ComputeServices is disabled
+    # @return [Bool]
+    def disabled?
+      status == 'disabled'
+    end
+
     class << self
       def enable(host, binary)
         params = {

--- a/test/yao/resources/test_compute_services.rb
+++ b/test/yao/resources/test_compute_services.rb
@@ -29,14 +29,14 @@ class TestComputeServices < TestYaoResource
 
   def test_enabled?
     compute_service = Yao::ComputeServices.new( 'status' => 'enabled' )
-    assert_equal(compute_service.enabled?, true)
-    assert_equal(compute_service.disabled?, false)
+    assert_true  compute_service.enabled?
+    assert_false compute_service.disabled?
   end
 
   def test_disabled?
     compute_service = Yao::ComputeServices.new( 'status' => 'disabled' )
-    assert_equal(compute_service.enabled?, false)
-    assert_equal(compute_service.disabled?, true)
+    assert_false compute_service.enabled?
+    assert_true  compute_service.disabled?
   end
 
   def test_enable

--- a/test/yao/resources/test_compute_services.rb
+++ b/test/yao/resources/test_compute_services.rb
@@ -27,6 +27,18 @@ class TestComputeServices < TestYaoResource
     assert_equal(compute_service.zone, "internal")
   end
 
+  def test_enabled?
+    compute_service = Yao::ComputeServices.new( 'status' => 'enabled' )
+    assert_equal(compute_service.enabled?, true)
+    assert_equal(compute_service.disabled?, false)
+  end
+
+  def test_disabled?
+    compute_service = Yao::ComputeServices.new( 'status' => 'disabled' )
+    assert_equal(compute_service.enabled?, false)
+    assert_equal(compute_service.disabled?, true)
+  end
+
   def test_enable
     stub = stub_request(:put, "https://example.com:12345/os-services/enable").
       with(


### PR DESCRIPTION
Hi This PR add two methods.

 * Yao::ComputeServices#enabled?
 * Yao::ComputeServices#disabled?

These methods is very simple,  just compare `status == 'enabled'` or `status == 'disabled'`. 

## わざわざメソッドを生やす理由

`compute_service.status == 'enable'` みたいに String の部分を typo してしまう事態を避けるのに有用だと思っております