### PR TITLE
Add methods and tests for Yao::Hypervisor

### DIFF
--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -16,7 +16,7 @@ module Yao::Resources
     end
 
     alias hostname hypervisor_hostname
-    alias type     hypervisor_hostname
+    alias type     hypervisor_type
     alias version  hypervisor_version
 
     self.service        = "compute"

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -17,6 +17,11 @@ module Yao::Resources
       self['status'] == 'enabled'
     end
 
+    # @return [Bool]
+    def disabled?
+      self['status'] == 'disabled'
+    end
+
     # @return [Yao::ComputeServices]
     def service
       Yao::ComputeServices.new(self['service'])

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -7,12 +7,19 @@ module Yao::Resources
                         :memory_mb, :memory_mb_used, :free_disk_gb,
                         :local_gb, :local_gb_used, :free_disk_gb, :status
 
+    # @return [Hash]
     def cpu_info
       JSON.parse self["cpu_info"]
     end
 
+    # @return [Bool]
     def enabled?
       self['status'] == 'enabled'
+    end
+
+    # @return [Yao::ComputeServices]
+    def service
+      Yao::ComputeServices.new(self['service'])
     end
 
     alias hostname hypervisor_hostname

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -73,6 +73,10 @@ class TestHypervisor < TestYaoResource
 
     # #enabled?
     assert_true(host.enabled?)
+
+    # #service
+    assert_instance_of(Yao::ComputeServices, host.service)
+    assert_equal(6, host.service.id)
   end
 
   def test_list

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -45,9 +45,6 @@ class TestHypervisor < TestYaoResource
 
     host = Yao::Hypervisor.new(params)
 
-    assert_true(host.enabled?)
-    assert_false(host.disabled?)
-
     assert_equal("host1", host.hypervisor_hostname)
     assert_equal("host1", host.hostname)
 
@@ -74,6 +71,7 @@ class TestHypervisor < TestYaoResource
 
     # #enabled?
     assert_true(host.enabled?)
+    assert_false(host.disabled?)
 
     # #service
     assert_instance_of(Yao::ComputeServices, host.service)

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -2,11 +2,77 @@ class TestHypervisor < TestYaoResource
 
   def test_hypervisor
     params = {
-      "status" => "enabled"
+      "current_workload" => 0,
+      "status" => "enabled",
+      "state" => "up",
+      "disk_available_least" => 0,
+      "host_ip" => "1.1.1.1",
+      "free_disk_gb" => 1028,
+      "free_ram_mb" => 7680,
+      "hypervisor_hostname" => "host1",
+      "hypervisor_type" => "fake",
+      "hypervisor_version" => 1000,
+      "id" => 2,
+      "local_gb" => 1028,
+      "local_gb_used" => 0,
+      "memory_mb" => 8192,
+      "memory_mb_used" => 512,
+      "running_vms" => 0,
+      "service" => {
+        "host" => "host1",
+        "id" => 6,
+        "disabled_reason" => nil,
+      },
+      "vcpus" => 2,
+      "vcpus_used" => 0
     }
 
+    # ooooooooooooooopsssssssssssss
+    params['cpu_info'] = {
+        "arch" => "x86_64",
+        "model" => "Nehalem",
+        "vendor" => "Intel",
+        "features" => [
+          "pge",
+          "clflush"
+        ],
+        "topology" => {
+          "cores" => 1,
+          "threads" => 1,
+          "sockets" => 4
+        }
+    }.to_json
+
     host = Yao::Hypervisor.new(params)
+
     assert_equal(true, host.enabled?)
+
+    assert_equal("host1", host.hypervisor_hostname)
+    assert_equal("host1", host.hostname)
+
+    assert_equal("fake", host.hypervisor_type)
+    assert_equal("fake", host.type)
+
+    assert_equal(1000, host.hypervisor_version)
+    assert_equal(1000, host.version)
+
+    assert_equal(0, host.running_vms)
+    assert_equal(0, host.current_workload)
+    assert_equal(2, host.vcpus)
+    assert_equal(0, host.vcpus_used)
+    assert_equal(8192, host.memory_mb)
+    assert_equal(512, host.memory_mb_used)
+    assert_equal(1028, host.free_disk_gb)
+    assert_equal(1028, host.local_gb)
+    assert_equal(0, host.local_gb_used)
+    assert_equal(1028, host.free_disk_gb)
+    assert_equal('enabled', host.status)
+
+    # #cpu_info
+    assert_equal('x86_64', host.cpu_info["arch"])
+
+    # #enabled?
+    assert_true(host.enabled?)
   end
 
   def test_list

--- a/test/yao/resources/test_hypervisor.rb
+++ b/test/yao/resources/test_hypervisor.rb
@@ -45,7 +45,8 @@ class TestHypervisor < TestYaoResource
 
     host = Yao::Hypervisor.new(params)
 
-    assert_equal(true, host.enabled?)
+    assert_true(host.enabled?)
+    assert_false(host.disabled?)
 
     assert_equal("host1", host.hypervisor_hostname)
     assert_equal("host1", host.hostname)


### PR DESCRIPTION
Hi Yao ! 

This PR add syntax sugar methods to Yao::Hypervisor

 * `#disabled?` returns Bool that indicates whether the hypervisor is disabled or not
 * `#service` returns Yao::ComptueService

----

テストを書いたついでに typo もあったので直しておきました