### PR TITLE
Fix: NoMethodError: undefined method `size'

### DIFF
--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -88,10 +88,8 @@ module Yao::Resources
 
       json = GET(url, query).body
       if return_single_on_querying && !query.empty?
-        # returns Yao::Resources::*
-        resource_from_json(json)
+        [resource_from_json(json)]
       else
-        # returns Array of Yao::Resources::*
         resources_from_json(json)
       end
     end

--- a/lib/yao/resources/user.rb
+++ b/lib/yao/resources/user.rb
@@ -10,14 +10,6 @@ module Yao::Resources
     self.admin          = true
 
     class << self
-      def find_by_name(name, query={})
-        if api_verion_v2?
-          [super]
-        else
-          super
-        end
-      end
-
       def return_single_on_querying
         api_verion_v2?
       end

--- a/test/support/restfully_accesible_stub.rb
+++ b/test/support/restfully_accesible_stub.rb
@@ -9,6 +9,17 @@ module RestfullAccessibleStub
       )
   end
 
+  def stub_get_request_with_json_response(url, body)
+    stub_request(:get, url)
+      .with(
+        headers: request_headers
+      ).to_return(
+        status: 200,
+        headers: {'Content-Type' => 'application/json'},
+        body: body.to_json
+      )
+  end
+
   def stub_get_request_not_found(url)
     stub_request(:get, url)
       .with(

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -38,7 +38,7 @@ class TestRestfullyAccesible < Test::Unit::TestCase
       assert_equal("OK", Test.get(id))
     end
 
-    test 'name' do
+    test 'name (return_single_on_querying = true)' do
       Test.return_single_on_querying = true
       name = "dummy"
       uuid = "00112233-4455-6677-8899-aabbccddeeff"
@@ -47,6 +47,21 @@ class TestRestfullyAccesible < Test::Unit::TestCase
       stub_get_request([@url, "#{@resources_name}?name=dummy"].join('/'), @resources_name)
       mock(Test).new("dummy_resource") { Struct.new(:id).new(uuid) }
       stub_get_request([@url, @resources_name, uuid].join('/'), @resources_name)
+      mock(Test).new("dummy_resource") { "OK" }
+
+      assert_equal("OK", Test.get(name))
+    end
+
+    test 'name' do
+      Test.return_single_on_querying = false
+      name = "dummy"
+      uuid = "00112233-4455-6677-8899-aabbccddeeff"
+      body = {@resources_name => [@resources_name]}
+
+      stub_get_request_not_found([@url, @resources_name, name].join('/'))
+      stub_get_request_with_json_response([@url, "#{@resources_name}?name=dummy"].join('/'), body)
+      mock(Test).new("dummy_resources") { Struct.new(:id).new(uuid) }
+      stub_get_request([@url, @resources_name, uuid].join('/'), @resource_name)
       mock(Test).new("dummy_resource") { "OK" }
 
       assert_equal("OK", Test.get(name))

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -45,7 +45,7 @@ class TestRestfullyAccesible < Test::Unit::TestCase
 
       stub_get_request_not_found([@url, @resources_name, name].join('/'))
       stub_get_request([@url, "#{@resources_name}?name=dummy"].join('/'), @resources_name)
-      mock(Test).new("dummy_resource") { [Struct.new(:id).new(uuid)] }
+      mock(Test).new("dummy_resource") { Struct.new(:id).new(uuid) }
       stub_get_request([@url, @resources_name, uuid].join('/'), @resources_name)
       mock(Test).new("dummy_resource") { "OK" }
 


### PR DESCRIPTION
Yao::Tenant.get を呼び出すと `NoMethodError: undefined method `size'`が発生するので修正しました。

再現手順

```
[3] yao(main)> Yao::Tenant.get("admin")
NoMethodError: undefined method `size' for #<Yao::Resources::Tenant:0x0000555df06742a8>
from /home/ykky/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/yao-0.8.0/lib/yao/resources/restfully_accessible.rb:205:in `rescue in get_by_name'
Caused by Yao::NotFound: The resource could not be found.
from /home/ykky/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/yao-0.8.0/lib/yao/faraday_middlewares.rb:129:in `on_complete'
```