### PR TITLE
Fix deprecated property for GitHub Actions

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Ruby
       uses: actions/setup-ruby@v1
       with:
-        version: ${{ matrix.ruby }}
+        ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
       run: |
         gem install bundler --no-document


### PR DESCRIPTION
以下のようなdeprecatedメッセージが出ていたので修正します。

![image](https://user-images.githubusercontent.com/1275643/67468158-fbac4d80-f684-11e9-8db5-86724cdaa884.png)
