### PR TITLE
add get! method

### DIFF
--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -115,6 +115,17 @@ module Yao::Resources
     end
     alias find get
 
+    # @param id_or_name_or_permalink [Stirng]
+    # @param query [Hash]
+    # @return [Yao::Resources::*]
+    def get!(id_or_name_or_permalink, query={})
+      return begin
+               get(id_or_name_or_permalink, query)
+             rescue Yao::ItemNotFound, Yao::NotFound
+               nil
+             end
+    end
+
     def find_by_name(name, query={})
       list(query.merge({"name" => name}))
     end

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -119,11 +119,9 @@ module Yao::Resources
     # @param query [Hash]
     # @return [Yao::Resources::*]
     def get!(id_or_name_or_permalink, query={})
-      return begin
-               get(id_or_name_or_permalink, query)
-             rescue Yao::ItemNotFound, Yao::NotFound
-               nil
-             end
+      get(id_or_name_or_permalink, query)
+    rescue Yao::ItemNotFound, Yao::NotFound
+      nil
     end
 
     def find_by_name(name, query={})

--- a/test/support/restfully_accesible_stub.rb
+++ b/test/support/restfully_accesible_stub.rb
@@ -19,6 +19,16 @@ module RestfullAccessibleStub
       )
   end
 
+  def stub_get_request_unauthorized(url)
+    stub_request(:get, url)
+      .with(
+        headers: request_headers
+      ).to_return(
+        status: 401,
+        body: "unauthorized"
+      )
+  end
+
   def request_headers
     {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>"Faraday v#{Faraday::VERSION}"}
   end

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -53,6 +53,27 @@ class TestRestfullyAccesible < Test::Unit::TestCase
     end
   end
 
+  sub_test_case 'get!' do
+    test 'not found' do
+      stub_get_request_not_found("https://example.com/dummy_resource")
+      assert_equal(nil, Test.get!("https://example.com/dummy_resource"))
+    end
+
+    test 'found' do
+      uuid = "00112233-4455-6677-8899-aabbccddeeff"
+      stub_get_request([@url, @resources_name, uuid].join('/'), @resource_name)
+      mock(Test).new("dummy_resource") { "OK" }
+      assert_equal("OK", Test.get!(uuid))
+    end
+
+    test 'other error' do
+      stub_get_request_unauthorized("https://example.com/dummy_resource")
+      assert_raises Yao::Unauthorized do
+        Test.get!("https://example.com/dummy_resource")
+      end
+    end
+  end
+
   def test_find_by_name
     mock(Test).list({"name" => "dummy"}) { "dummy" }
 


### PR DESCRIPTION
If the resource does not exist, Yao :: ItemNotFound will be raised, but this can be annoying.
`get!` method returns nil without throwing an exception if the resource does not exist.

- - - -

リソースが存在しない場合はYao::ItemNotFoundがraiseされますが、それが煩わしいことがあります。
get! メソッドはリソースが存在しない場合例外を投げずにnilを返却します。