### PR TITLE
fix: Yao::Meter.list does not return array of Yao::Resources::Meter instance.

### DIFF
--- a/lib/yao/resources/meter.rb
+++ b/lib/yao/resources/meter.rb
@@ -28,7 +28,7 @@ module Yao::Resources
       end
 
       def resources_from_json(json)
-        new(json)
+        json.map{|d| new(d)}
       end
     end
   end

--- a/lib/yao/resources/meter.rb
+++ b/lib/yao/resources/meter.rb
@@ -27,6 +27,9 @@ module Yao::Resources
         new(json)
       end
 
+      # override Yao::Resources::RestfullyAccessible.resources_from_json
+      # @param [Array]
+      # @return [Array<Yao::Resources::Meter>]
       def resources_from_json(json)
         json.map{|d| new(d)}
       end

--- a/test/yao/resources/test_meter.rb
+++ b/test/yao/resources/test_meter.rb
@@ -27,6 +27,42 @@ class TestMeter < TestYaoResource
     assert_equal("efd87807-12d2-4b38-9c70-5f5c2ac427ff", meter.user_id)
   end
 
+  def test_list
+    stub = stub_request(:get, "https://example.com:12345/v2/meters")
+               .to_return(
+                   status: 200,
+                   # https://docs.openstack.org/ceilometer/pike/webapi/v2.html#meters
+                   body: <<-JSON,
+                   [
+                     {
+                       "meter_id": "YmQ5NDMxYzEtOGQ2OS00YWQzLTgwM2EtOGQ0YTZiODlmZDM2K2luc3RhbmNl",
+                       "name": "instance",
+                       "project_id": "35b17138-b364-4e6a-a131-8f3099c5be68",
+                       "resource_id": "bd9431c1-8d69-4ad3-803a-8d4a6b89fd36",
+                       "source": "openstack",
+                       "type": "gauge",
+                       "unit": "instance",
+                       "user_id": "efd87807-12d2-4b38-9c70-5f5c2ac427ff"
+                     },
+                     {
+                       "meter_id": "YmQ5NDMxYzEtOGQ2OS00YWQzLTgwM2EtOGQ0YTZiODlmZDM2K2luc3RhbmNl",
+                       "name": "instance",
+                       "project_id": "35b17138-b364-4e6a-a131-8f3099c5be68",
+                       "resource_id": "bd9431c1-8d69-4ad3-803a-8d4a6b89fd36",
+                       "source": "openstack",
+                       "type": "gauge",
+                       "unit": "instance",
+                       "user_id": "efd87807-12d2-4b38-9c70-5f5c2ac427ff"
+                     }
+                   ]
+                   JSON
+                   headers: {'Content-Type' => 'application/json'}
+               )
+    meters = Yao::Meter.list
+    assert_instance_of(Array, meters)
+    assert_requested(stub)
+  end
+
   def test_resource
     # https://docs.openstack.org/ceilometer/pike/webapi/v2.html
     stub = stub_request(:get, "https://example.com:12345/v2/resources/00000000-0000-0000-0000-000000000000")


### PR DESCRIPTION
fix: https://github.com/yaocloud/yao/issues/141