### PR TITLE
Yao::Tenant の servers インスタンスメソッドが動作しない問題を修正します

### DIFF
--- a/lib/yao/resources/project.rb
+++ b/lib/yao/resources/project.rb
@@ -13,7 +13,7 @@ module Yao::Resources
     end
 
     def servers
-      @servers ||= Yao::Server.list(project_id: id)
+      @servers ||= Yao::Server.list(all_tenants: 1, project_id: id)
     end
 
     def ports

--- a/lib/yao/resources/tenant.rb
+++ b/lib/yao/resources/tenant.rb
@@ -9,7 +9,7 @@ module Yao::Resources
     self.return_single_on_querying = true
 
     def servers
-      @servers ||= Yao::Server.list(project_id: id)
+      @servers ||= Yao::Server.list(all_tenants: 1, project_id: id)
     end
 
     def meters

--- a/test/yao/resources/test_project.rb
+++ b/test/yao/resources/test_project.rb
@@ -150,7 +150,7 @@ class TestProject < TestYaoResource
   end
 
   def test_servers
-    stub = stub_request(:get, "https://example.com:12345/servers/detail?project_id=6f70656e737461636b20342065766572")
+    stub = stub_request(:get, "https://example.com:12345/servers/detail?all_tenants=1&project_id=6f70656e737461636b20342065766572")
                .to_return(
                    status: 200,
                    # https://docs.openstack.org/api-ref/compute/?expanded=list-servers-detailed-detail#list-servers-detailed


### PR DESCRIPTION
https://github.com/yaocloud/yao/commit/91e2eeb332c1173f46917bc102bf9faf35474d25 の変更により、Yao::Tenantの servers インスタンスメソッドが空配列を返すようになったためこれを修正します。

原因ですが、HavanaのAPIでインスタンス一覧を取得する際、 `all_tenants` オプションがない場合 `project_id`で正しく絞り込めない…というものです。

```
Yao::Server.list(project_id: id)
```

`all_tenants` を有効にすることでテナントに所属するインスタンス一覧が返ってきます。

```
Yao::Server.list(all_tenants: 1, project_id: id)
```