### PR TITLE
add Yao::Resources::Hypervisor#lib/yao/resources

### DIFF
--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -23,11 +23,11 @@ module Yao::Resources
     end
 
     def servers
-      res = POST("/os-hypervisors") do |req|
+      res = GET("/os-hypervisors") do |req|
         req.body = { "hostname-patterns" => self.hostname }.to_json
         req.headers["Content-Type"] = "application/json"
       end
-      res["servers"]
+      res.body["servers"].map{ |s| resource_from_json(s) }
     end
 
     # @return [Yao::ComputeServices]

--- a/lib/yao/resources/hypervisor.rb
+++ b/lib/yao/resources/hypervisor.rb
@@ -22,6 +22,14 @@ module Yao::Resources
       self['status'] == 'disabled'
     end
 
+    def servers
+      res = POST("/os-hypervisors") do |req|
+        req.body = { "hostname-patterns" => self.hostname }.to_json
+        req.headers["Content-Type"] = "application/json"
+      end
+      res["servers"]
+    end
+
     # @return [Yao::ComputeServices]
     def service
       Yao::ComputeServices.new(self['service'])


### PR DESCRIPTION
Openstack APIにはハイパーバイザ上の全サーバを取得するエンドポイントが存在するが,  
現在YaocloudにはそのようなAPIが存在しない.  

ここでは `Yao::Hypervisor` のインスタンスメソッドに `servers` を追加し,  
サーバを取得できるようにした.  

