### PR TITLE
Fix: warning: Using the last argument as keyword parameters is deprecated

### DIFF
--- a/lib/yao/plugins/registry.rb
+++ b/lib/yao/plugins/registry.rb
@@ -29,7 +29,7 @@ module Yao::Plugins
   # @param [*]
   # @param [Symbol]
   # @param [Symbol]
-  def self.register(*a)
-    Registry.instance.register(*a)
+  def self.register(klass, **kw)
+    Registry.instance.register(klass, **kw)
   end
 end


### PR DESCRIPTION
see. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/