### PR TITLE
Temporarily chang ruby-head to ruby-2.7.0

### DIFF
--- a/.github/workflows/ubuntu-rvm.yml
+++ b/.github/workflows/ubuntu-rvm.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'ruby-head' ]
+        ruby: [ 'ruby-2.7.0' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up RVM


### PR DESCRIPTION
`rvm install ruby-head --binary` するとbinaryが見つからないエラーになってしまうので一時的にruby-2.7.0を指定します。
次のバージョンのrubyが出たら戻します。