### PR TITLE
Fix: warning: Passing the keyword argument as the last hash parameter is deprecated

### DIFF
--- a/lib/yao/client.rb
+++ b/lib/yao/client.rb
@@ -107,7 +107,10 @@ module Yao
       # @param [String]
       def reset_client(new_endpoint=nil)
         set = ClientSet.new
-        set.register_endpoints("default" => {public_url: new_endpoint || Yao.config.endpoint})
+        endpoint = {
+          "default" => {public_url: new_endpoint || Yao.config.endpoint}
+        }
+        set.register_endpoints(endpoint)
         self.default_client = set
       end
 


### PR DESCRIPTION
deprecatedなメッセージが出ているので直します。
see. https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/