### PR TITLE
add suppert default domain

### DIFF
--- a/lib/yao/auth.rb
+++ b/lib/yao/auth.rb
@@ -19,6 +19,7 @@ module Yao
       end
 
       def build_authv3_info(tenant_name, username, password,
+                            default_domain,
                             user_domain_id, user_domain_name,
                             project_domain_id, project_domain_name)
           identity = {
@@ -31,6 +32,8 @@ module Yao
             identity[:password][:user][:domain] = { id: user_domain_id }
           elsif user_domain_name
             identity[:password][:user][:domain] = { name: user_domain_name }
+          elsif default_domain
+            identity[:password][:user][:domain] = { id: default_domain }
           end
 
           scope = {
@@ -40,6 +43,8 @@ module Yao
             scope[:project][:domain] = { id: project_domain_id }
           elsif project_domain_name
             scope[:project][:domain] = { name: project_domain_name }
+          elsif default_domain
+            scope[:project][:domain] = { id: default_domain }
           end
 
           {
@@ -68,6 +73,7 @@ module Yao
           username: Yao.config.username,
           password: Yao.config.password,
           identity_api_version: Yao.config.identity_api_version,
+          default_domain: Yao.config.default_domain,
           user_domain_id: Yao.config.user_domain_id,
           user_domain_name: Yao.config.user_domain_name,
           project_domain_id: Yao.config.project_domain_id,
@@ -75,6 +81,7 @@ module Yao
       )
         if identity_api_version.to_i == 3
           auth_info = build_authv3_info(tenant_name, username, password,
+                                        default_domain,
                                         user_domain_id, user_domain_name,
                                         project_domain_id, project_domain_name)
           issue = TokenV3.issue(Yao.default_client.default, auth_info)

--- a/lib/yao/client.rb
+++ b/lib/yao/client.rb
@@ -148,6 +148,8 @@ module Yao
     Yao::Client.default_client
   end
 
+  Yao.config.param :default_domain, 'default'
+
   Yao.config.param :noop_on_write, false
   Yao.config.param :raise_on_write, false
 

--- a/test/yao/test_authv3.rb
+++ b/test/yao/test_authv3.rb
@@ -103,18 +103,22 @@ class TestAuthV3 < Test::Unit::TestCase
   end
 
   def test_build_authv3_info
-    auth_info = Yao::Auth.build_authv3_info("example", "udzura", "XXXXXXXX", "default", nil, "default", nil)
+    auth_info = Yao::Auth.build_authv3_info("example", "udzura", "XXXXXXXX", "test", nil, nil, nil, nil)
 
     user = auth_info[:auth][:identity][:password][:user]
     assert { user[:name] == "udzura" }
     assert { user[:password] == "XXXXXXXX" }
-    assert { user[:domain][:id] == "default" }
+    assert { user[:domain][:id] == "test" }
 
     project = auth_info[:auth][:scope][:project]
     assert { project[:name] == "example" }
-    assert { project[:domain][:id] == "default" }
+    assert { project[:domain][:id] == "test" }
 
-    auth_info = Yao::Auth.build_authv3_info("example", "udzura", "XXXXXXXX", nil, "default", nil, "default")
+    auth_info = Yao::Auth.build_authv3_info("example", "udzura", "XXXXXXXX", nil, "default", nil, "default", nil)
+    assert { auth_info[:auth][:identity][:password][:user][:domain][:id] == "default" }
+    assert { auth_info[:auth][:scope][:project][:domain][:id] == "default" }
+
+    auth_info = Yao::Auth.build_authv3_info("example", "udzura", "XXXXXXXX", nil, nil, "default", nil, "default")
     assert { auth_info[:auth][:identity][:password][:user][:domain][:name] == "default" }
     assert { auth_info[:auth][:scope][:project][:domain][:name] == "default" }
   end


### PR DESCRIPTION
openstackclientでいうところの--os-default-domainの機能を追加します。
Yao.config.default_domainを設定するとYao.config.project_domain_id / Yao.config.user_domain_id を設定することができます。
https://github.com/openstack/python-openstackclient/commit/1d75edb1678e42a36879245c6ebac69c14a5f965