### PR TITLE
Add get_vnc_console

### DIFF
--- a/lib/yao/resources/action.rb
+++ b/lib/yao/resources/action.rb
@@ -5,7 +5,7 @@ module Yao::Resources
         req.body = query.to_json
         req.headers['Content-Type'] = 'application/json'
       end
-      res.body ? resource_from_json(res.body) : nil
+      res.body
     end
 
     private

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -53,6 +53,10 @@ module Yao::Resources
       action(id, {"removeSecurityGroup": {"name": sg_name}})
     end
 
+    def self.get_vnc_console(id)
+      action(id, {"os-getVNCConsole": {"type": "novnc"}})["console"]["url"]
+    end
+
     class << self
       alias :stop :shutoff
     end

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -54,7 +54,8 @@ module Yao::Resources
     end
 
     def self.get_vnc_console(id)
-      action(id, {"os-getVNCConsole": {"type": "novnc"}})["console"]["url"]
+      response = action(id, {"os-getVNCConsole": {"type": "novnc"}})
+      response.dig("console", "url")
     end
 
     class << self


### PR DESCRIPTION
VNCコンソールのURLを取得したいが，対応したメソッドが無かったので実装しました．
Yaoでは現状，[サーバーに関する操作](https://github.com/yaocloud/yao/blob/master/lib/yao/resources/server.rb) では`/servers/{server_id}/action`への[POSTを行なっている](https://github.com/yaocloud/yao/blob/3dab76418b3b338670acef6bd0c675493409dae9/lib/yao/resources/server.rb#L33)と認識しています.
同じエンドポイントを利用してconsoleのURLを取得できるAPIが[あった](https://docs.openstack.org/api-ref/compute/?expanded=create-or-update-metadata-items-detail,reboot-server-reboot-action-detail#get-vnc-console-os-getvncconsole-action-deprecated)ので，これを使って実装しようかと思ったものの，[`action`](https://github.com/yaocloud/yao/blob/3dab76418b3b338670acef6bd0c675493409dae9/lib/yao/resources/action.rb#L3)はres.bodyがnilでない時は[`resource_from_json`](https://github.com/yaocloud/yao/blob/3dab76418b3b338670acef6bd0c675493409dae9/lib/yao/resources/restfully_accessible.rb#L184)を返しており，本来レスポンスに含まれるURLが取得できません．

[ドキュメント](https://docs.openstack.org/api-ref/compute/?expanded=create-or-update-metadata-items-detail,get-vnc-console-os-getvncconsole-action-deprecated-detail,resize-server-resize-action-detail#start-server-os-start-action)によると，現在actionを使って実装されている操作は皆，レスポンスのbodyがnilなので．resource_from_jsonを通さずにそのまま返しても挙動が変わらず，かつレスポンスにjsonが含まれていてもそのまま取得できます．