### PR TITLE
Fix tenant detection in role, in v2 API mode

### DIFF
--- a/lib/yao/error.rb
+++ b/lib/yao/error.rb
@@ -1,6 +1,7 @@
 module Yao
   class ReadOnlyViolationError < ::StandardError; end
   class TooManyItemFonud       < ::StandardError; end
+  class InvalidResponse        < ::StandardError; end
 
   class ServerError < ::StandardError
     def initialize(message, requested_env)

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -211,6 +211,8 @@ module Yao::Resources
         item = find_by_name(name)
         if item.size > 1
           raise Yao::TooManyItemFonud.new("More than one resource exists with the name '#{name}'")
+        elsif item.size.zero?
+          raise Yao::InvalidResponse.new("No resource exists with the name '#{name}'")
         end
         GET(create_url(item.first.id), query)
       end

--- a/lib/yao/resources/role.rb
+++ b/lib/yao/resources/role.rb
@@ -37,7 +37,7 @@ module Yao::Resources
       def list_for_user(user_name, on:)
         user   = Yao::User.get(user_name)
         tenant = if api_version_v2?
-                   Yao::Tenant.find_by_name(on)
+                   Yao::Tenant.get(on)
                  else
                    Yao::Project.get(on)
                  end
@@ -54,7 +54,7 @@ module Yao::Resources
         role   = Yao::Role.get(role_name)
         user   = Yao::User.get(to)
         tenant = if api_version_v2?
-                   Yao::Tenant.find_by_name(on)
+                   Yao::Tenant.get(on)
                  else
                    Yao::Project.get(on)
                  end
@@ -71,7 +71,7 @@ module Yao::Resources
         role   = Yao::Role.get(role_name)
         user   = Yao::User.get(from)
         tenant = if api_version_v2?
-                   Yao::Tenant.find_by_name(on)
+                   Yao::Tenant.get(on)
                  else
                    Yao::Project.get(on)
                  end

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -66,6 +66,20 @@ class TestRestfullyAccesible < Test::Unit::TestCase
 
       assert_equal("OK", Test.get(name))
     end
+
+    test 'name (with no item JSON)' do
+      Test.return_single_on_querying = false
+      name = "dummy2"
+      uuid = "00112233-4455-6677-8899-aabbccddeeff"
+      body = {@resources_name => []}
+
+      stub_get_request_not_found([@url, @resources_name, name].join('/'))
+      stub_get_request_with_json_response([@url, "#{@resources_name}?name=#{name}"].join('/'), body)
+
+      assert_raise(Yao::InvalidResponse, "raise proper exception") do
+        Test.get(name)
+      end
+    end
   end
 
   sub_test_case 'get!' do

--- a/test/yao/resources/test_role.rb
+++ b/test/yao/resources/test_role.rb
@@ -60,7 +60,7 @@ class TestRole < TestYaoResource
       assert_equal("0123456789abcdef0123456789abcdef", roles.first.id)
       assert_requested(stub)
     end
-    
+
     def test_list_for_user
       stub_user
       stub_tenant
@@ -77,11 +77,11 @@ class TestRole < TestYaoResource
           JSON
           headers: {'Content-Type' => 'application/json'}
         )
-      
+
       roles = Yao::Role.list_for_user("test_user", on:"admin")
       assert_equal("0123456789abcdef0123456789abcdef", roles.first.id)
       assert_received(Yao::User) { |subject| subject.get("test_user") }
-      assert_received(Yao::Tenant) { |subject| subject.find_by_name("admin") }
+      assert_received(Yao::Tenant) { |subject| subject.get("admin") }
       assert_requested(stub)
     end
 
@@ -99,7 +99,7 @@ class TestRole < TestYaoResource
       Yao::Role.grant("test_role", to:"test_user", on:"admin")
       assert_received(Yao::Role) { |subject| subject.get("test_role") }
       assert_received(Yao::User) { |subject| subject.get("test_user") }
-      assert_received(Yao::Tenant) { |subject| subject.find_by_name("admin") }
+      assert_received(Yao::Tenant) { |subject| subject.get("admin") }
       assert_requested(stub)
     end
 
@@ -117,7 +117,7 @@ class TestRole < TestYaoResource
       Yao::Role.revoke("test_role", from:"test_user", on:"admin")
       assert_received(Yao::Role) { |subject| subject.get("test_role") }
       assert_received(Yao::User) { |subject| subject.get("test_user") }
-      assert_received(Yao::Tenant) { |subject| subject.find_by_name("admin") }
+      assert_received(Yao::Tenant) { |subject| subject.get("admin") }
       assert_requested(stub)
     end
   end
@@ -172,7 +172,7 @@ class TestRole < TestYaoResource
       assert_equal("0123456789abcdef0123456789abcdef", roles.first.id)
       assert_requested(stub)
     end
-    
+
     def test_list_for_user
       stub_user
       stub_project
@@ -189,7 +189,7 @@ class TestRole < TestYaoResource
           JSON
           headers: {'Content-Type' => 'application/json'}
         )
-      
+
       roles = Yao::Role.list_for_user("test_user", on:"admin")
       assert_equal("0123456789abcdef0123456789abcdef", roles.first.id)
       assert_received(Yao::Resources::User) { |subject| subject.get("test_user") }
@@ -249,9 +249,9 @@ class TestRole < TestYaoResource
       "name" => "test_user",
     }) }
   end
-  
+
   def stub_tenant
-    stub(Yao::Tenant).find_by_name { Yao::Tenant.new({
+    stub(Yao::Tenant).get { Yao::Tenant.new({
       "id" => "0123456789abcdef0123456789abcdef",
       "name" => "admin",
     }) }


### PR DESCRIPTION
Retry of https://github.com/yaocloud/yao/pull/165 

> find_by_name is expected to return Array.

So now I am using `get`.