### PR TITLE
Conseal token at debug print

### DIFF
--- a/lib/yao/faraday_middlewares.rb
+++ b/lib/yao/faraday_middlewares.rb
@@ -68,7 +68,7 @@ class Faraday::Response::OSDumper < Faraday::Response::Middleware
   def on_complete(env)
     require 'pp'
 
-    body = if env.response_headers["content-type"] == "application/json"
+    body = if env.response_headers["content-type"].start_with?("application/json")
              JSON.parse(env.body)
            else
              env.body

--- a/lib/yao/plugins/default_client_generator.rb
+++ b/lib/yao/plugins/default_client_generator.rb
@@ -19,7 +19,6 @@ module Yao::Plugins
       f.response :json, content_type: /\bjson$/
 
       if Yao.config.debug
-        f.response :logger
         f.response :os_dumper
       end
 

--- a/test/yao/test_client.rb
+++ b/test/yao/test_client.rb
@@ -48,7 +48,6 @@ class TestClient < Test::Unit::TestCase
       Faraday::Request::ReadOnly,
       Faraday::Response::OSErrorDetector,
       FaradayMiddleware::ParseJson,
-      Faraday::Response::Logger,
       Faraday::Response::OSDumper
     ]
     assert { cli.builder.handlers == handlers }


### PR DESCRIPTION
YAO_DEBUG=1のときに表示されるデバッグログから、トークン情報を隠します。
デバッグ情報を貼り付けてもらうときに、トークンを毎回手動で隠す必要がなくなります。