### PR TITLE
friendly_attributes以外でもインスタンス化する

### DIFF
--- a/lib/yao/resources/base.rb
+++ b/lib/yao/resources/base.rb
@@ -8,9 +8,6 @@ module Yao::Resources
     def self.friendly_attributes(*names)
       names.map(&:to_s).each do |name|
         define_method(name) do
-          if !@data.key?(name) && id
-            @data = self.class.get(id).to_hash
-          end
           self[name]
         end
       end
@@ -58,6 +55,9 @@ module Yao::Resources
     # @param name [String]
     # @return [String]
     def [](name)
+      unless @data["id"].nil? || @data.key?(name) || name.include?("__")
+        @data = self.class.get(@data["id"]).to_hash
+      end
       @data[name]
     end
 
@@ -80,14 +80,14 @@ module Yao::Resources
 
     # @return [Date]
     def created
-      if date = self["created"] || self["created_at"]
+      if date = self["created_at"] || self["created"]
         Time.parse(date)
       end
     end
 
     # @return [Date]
     def updated
-      if date = self["updated"] || self["updated_at"]
+      if date = self["updated_at"] || self["updated"]
         Time.parse(date)
       end
     end

--- a/yao.gemspec
+++ b/yao.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "json"
   spec.add_dependency "deep_merge"
-  spec.add_dependency "faraday", "~> 1.8.0"
+  spec.add_dependency "faraday", ">= 1.8.0"
   spec.add_dependency "faraday_middleware"
 end


### PR DESCRIPTION
例えば、以下のようなコードを書くとエラーになってしまうのを解消する。

```
yrb(main):001:0> Yao::LoadBalancer.get("70d9c126-b606-4be4-9e1c-3d69f61fd2cb").pools.first.members
/home/ykky/.asdf/installs/ruby/3.1.1/lib/ruby/gems/3.1.0/gems/yao-0.15.0/lib/yao/resources/loadbalancer_pool.rb:37:in `members': undefined method `map' for nil:NilClass (NoMethodError)  
                                                                   
      self["members"].map do |member|                              
                     ^^^^                                          
-- snip --
```
