### PR TITLE
Yao::Routerの空の値が返ってくる各メソッドを定義しなおす

### DIFF
--- a/lib/yao/resources/router.rb
+++ b/lib/yao/resources/router.rb
@@ -3,12 +3,28 @@ module Yao::Resources
     include TenantAssociationable
 
     friendly_attributes :name, :description, :admin_state_up, :status, :external_gateway_info,
-                        :network_id, :enable_snat, :external_fixed_ips, :routes, :destination, :nexthop, :distributed,
-                        :ha, :availability_zone_hints, :availability_zones
+                        :routes, :distributed, :ha, :availability_zone_hints, :availability_zones
 
     self.service        = 'network'
     self.resource_name  = 'router'
     self.resources_name = 'routers'
+
+    # @return [bool]
+    def enable_snat
+      external_gateway_info["enable_snat"]
+    end
+
+    # @return [Array<Hash>]
+    def external_fixed_ips
+      external_gateway_info["external_fixed_ips"]
+    end
+
+    # @return [Yao::Resource::Network]
+    def external_network
+      @external_network ||= if network_id = external_gateway_info["network_id"]
+                              Yao::Network.get(network_id)
+                            end
+    end
 
     # @return [Array<Yao::Resources::Port>]
     def interfaces

--- a/lib/yao/resources/router.rb
+++ b/lib/yao/resources/router.rb
@@ -45,13 +45,6 @@ module Yao::Resources
       def remove_interface(id, param)
         PUT(['routers', id, 'remove_router_interface.json'].join('/'), param.to_json)
       end
-
-      # @param name [String]
-      # @return [Array<Yao::Resources::Router>]
-      def get_by_name(name)
-        self.list(name: name)
-      end
-      alias find_by_name get_by_name
     end
   end
 end


### PR DESCRIPTION
friendly_attributesとしていくつかのメソッドが定義されているが、実装がまずく常にnilが返ってくるため正しく実装しなおす。
これによりpendingになっていたテストも解消される。