### PR TITLE
Replace tenant to project

### DIFF
--- a/lib/yao/resources.rb
+++ b/lib/yao/resources.rb
@@ -1,7 +1,7 @@
 module Yao
   module Resources
     require "yao/resources/base"
-    require "yao/resources/tenant_associationable"
+    require "yao/resources/project_associationable"
     require "yao/resources/port_associationable"
     require "yao/resources/network_associationable"
     require "yao/resources/server_usage_associationable"

--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -2,7 +2,7 @@ module Yao::Resources
   class FloatingIP < Base
 
     include PortAssociationable
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :router_id, :description, :dns_domain, :dns_name,
                         :revision_number,
@@ -18,11 +18,5 @@ module Yao::Resources
     def router
       @router ||= Yao::Router.get(router_id)
     end
-
-    # @return [Yao::Resources::Tenant]
-    def project
-      @project ||= Yao::Tenant.get(project_id)
-    end
-    alias :tenant :project
   end
 end

--- a/lib/yao/resources/meter.rb
+++ b/lib/yao/resources/meter.rb
@@ -1,7 +1,7 @@
 module Yao::Resources
   class Meter < Base
 
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :meter_id, :name, :user_id, :resource_id, :source, :type, :unit
 

--- a/lib/yao/resources/network.rb
+++ b/lib/yao/resources/network.rb
@@ -1,6 +1,6 @@
 module Yao::Resources
   class Network < Base
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :name, :status, :shared, :subnets, :admin_state_up
     map_attribute_to_attribute "provider:physical_network" => :physical_network

--- a/lib/yao/resources/old_sample.rb
+++ b/lib/yao/resources/old_sample.rb
@@ -1,6 +1,6 @@
 module Yao::Resources
   class OldSample < Base
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :counter_name, :counter_type, :counter_unit, :counter_volume,
                         :message_id, :resource_id, :timestamp, :resource_metadata, :user_id,

--- a/lib/yao/resources/port.rb
+++ b/lib/yao/resources/port.rb
@@ -2,7 +2,7 @@ module Yao::Resources
   class Port < Base
 
     include NetworkAssociationable
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :name, :mac_address, :status, :allowed_address_pairs,
                         :device_owner, :fixed_ips, :security_groups, :device_id,

--- a/lib/yao/resources/project_associationable.rb
+++ b/lib/yao/resources/project_associationable.rb
@@ -1,18 +1,18 @@
 module Yao
   module Resources
-    module TenantAssociationable
+    module ProjectAssociationable
 
       def self.included(base)
         base.friendly_attributes :project_id
         base.friendly_attributes :tenant_id
       end
 
-      # @return [Yao::Resources::Tenant]
-      def tenant
-        @tenant ||= Yao::Tenant.find(project_id || tenant_id)
+      # @return [Yao::Resources::Project]
+      def project
+        @project ||= Yao::Project.find(project_id || tenant_id)
       end
 
-      alias :project :tenant
+      alias :tenant :project
     end
   end
 end

--- a/lib/yao/resources/resource.rb
+++ b/lib/yao/resources/resource.rb
@@ -1,7 +1,7 @@
 require 'time'
 module Yao::Resources
   class Resource < Base
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :user_id, :resource_id,
                         :last_sample_timestamp, :first_sample_timestamp,

--- a/lib/yao/resources/role_assignment.rb
+++ b/lib/yao/resources/role_assignment.rb
@@ -11,9 +11,9 @@ module Yao::Resources
     self.admin          = true
     self.api_version    = "v3"
 
-    # @return [Yao::Resources::Tenant]
+    # @return [Yao::Resources::Project]
     def project
-      @project ||= Yao::Tenant.get(scope["project"]["id"])
+      @project ||= Yao::Project.get(scope["project"]["id"])
     end
 
     class << self

--- a/lib/yao/resources/router.rb
+++ b/lib/yao/resources/router.rb
@@ -1,6 +1,6 @@
 module Yao::Resources
   class Router < Base
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :name, :description, :admin_state_up, :status, :external_gateway_info,
                         :routes, :distributed, :ha, :availability_zone_hints, :availability_zones

--- a/lib/yao/resources/security_group.rb
+++ b/lib/yao/resources/security_group.rb
@@ -1,7 +1,7 @@
 require 'yao/resources/security_group_rule'
 module Yao::Resources
   class SecurityGroup < Base
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :name, :description
 

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -2,7 +2,7 @@ require 'yao/resources/metadata_available'
 require 'yao/resources/action'
 module Yao::Resources
   class Server < Base
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :addresses, :metadata, :name, :progress,
                         :status, :user_id, :key_name

--- a/lib/yao/resources/subnet.rb
+++ b/lib/yao/resources/subnet.rb
@@ -2,7 +2,7 @@ module Yao::Resources
   class Subnet < Base
 
     include NetworkAssociationable
-    include TenantAssociationable
+    include ProjectAssociationable
 
     friendly_attributes :name, :cidr, :gateway_ip, :network_id, :ip_version,
                         :dns_nameservers, :host_routes, :enable_dhcp

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -82,14 +82,14 @@ class TestFloatingIP < TestYaoResource
     assert_requested(stub)
   end
 
-  def test_tenant
+  def test_project
 
-    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/projects/0123456789abcdef0123456789abcdef")
       .to_return(
          status: 200,
          body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "0123456789abcdef0123456789abcdef"
           }
         }
@@ -102,8 +102,8 @@ class TestFloatingIP < TestYaoResource
       "tenant_id"  => "0123456789abcdef0123456789abcdef",
     )
 
-    assert_instance_of(Yao::Tenant, fip.tenant)
-    assert_instance_of(Yao::Tenant, fip.project)
+    assert_instance_of(Yao::Project, fip.tenant)
+    assert_instance_of(Yao::Project, fip.project)
     assert_equal('0123456789abcdef0123456789abcdef', fip.tenant.id)
 
     assert_requested(stub)

--- a/test/yao/resources/test_meter.rb
+++ b/test/yao/resources/test_meter.rb
@@ -88,13 +88,13 @@ class TestMeter < TestYaoResource
     assert_requested(stub)
   end
 
-  def test_tenant
-    stub = stub_request(:get, "https://example.com:12345/tenants/00000000-0000-0000-0000-000000000000")
+  def test_project
+    stub = stub_request(:get, "https://example.com:12345/projects/00000000-0000-0000-0000-000000000000")
       .to_return(
         status: 200,
         body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "00000000-0000-0000-0000-000000000000"
           }
         }
@@ -107,8 +107,8 @@ class TestMeter < TestYaoResource
     }
 
     meter  = Yao::Meter.new(params)
-    assert_instance_of(Yao::Tenant, meter.tenant)
-    assert_equal("00000000-0000-0000-0000-000000000000", meter.tenant.id)
+    assert_instance_of(Yao::Project, meter.project)
+    assert_equal("00000000-0000-0000-0000-000000000000", meter.project.id)
 
     assert_requested(stub)
   end

--- a/test/yao/resources/test_network.rb
+++ b/test/yao/resources/test_network.rb
@@ -37,14 +37,14 @@ class TestNetwork < TestYaoResource
     assert_equal(1000, network.segmentation_id)
   end
 
-  def test_tenant
+  def test_project
 
-    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/projects/0123456789abcdef0123456789abcdef")
       .to_return(
          status: 200,
          body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "0123456789abcdef0123456789abcdef"
           }
         }
@@ -57,9 +57,9 @@ class TestNetwork < TestYaoResource
       "tenant_id"  => "0123456789abcdef0123456789abcdef",
     )
 
-    assert_instance_of(Yao::Tenant, network.tenant)
-    assert_instance_of(Yao::Tenant, network.project)
-    assert_equal('0123456789abcdef0123456789abcdef', network.tenant.id)
+    assert_instance_of(Yao::Project, network.tenant)
+    assert_instance_of(Yao::Project, network.project)
+    assert_equal('0123456789abcdef0123456789abcdef', network.project.id)
 
     assert_requested(stub)
   end

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -77,14 +77,14 @@ class TestPort < TestYaoResource
     assert_equal("10.0.0.1", port.primary_ip)
   end
 
-  def test_tenant
+  def test_project
 
-    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/projects/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "0123456789abcdef0123456789abcdef"
           }
         }
@@ -92,9 +92,9 @@ class TestPort < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
-    port = Yao::Port.new('tenant_id' => '0123456789abcdef0123456789abcdef')
-    assert_instance_of(Yao::Tenant, port.tenant)
-    assert_equal('0123456789abcdef0123456789abcdef', port.tenant.id)
+    port = Yao::Port.new('project_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Project, port.project)
+    assert_equal('0123456789abcdef0123456789abcdef', port.project.id)
 
     assert_requested(stub)
   end

--- a/test/yao/resources/test_role_assignment.rb
+++ b/test/yao/resources/test_role_assignment.rb
@@ -130,12 +130,12 @@ class TestRoleAssignment < TestYaoResource
   end
 
   def test_project
-    stub = stub_request(:get, "https://example.com:12345/tenants/456789").
+    stub = stub_request(:get, "https://example.com:12345/projects/456789").
       to_return(
         status: 200,
         body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "456789"
           }
         }
@@ -152,7 +152,7 @@ class TestRoleAssignment < TestYaoResource
     }
 
     role_assignment = Yao::RoleAssignment.new(params)
-    assert_instance_of(Yao::Resources::Tenant, role_assignment.project)
+    assert_instance_of(Yao::Project, role_assignment.project)
     assert_equal("456789", role_assignment.project.id)
 
     assert_requested(stub)

--- a/test/yao/resources/test_router.rb
+++ b/test/yao/resources/test_router.rb
@@ -150,14 +150,14 @@ class TestRouter < TestYaoResource
     assert_requested(stub)
   end
 
-  def test_tenant
+  def test_project
 
-    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/projects/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "0123456789abcdef0123456789abcdef"
           }
         }
@@ -165,9 +165,9 @@ class TestRouter < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
-    router = Yao::Router.new('tenant_id' => '0123456789abcdef0123456789abcdef')
-    assert_instance_of(Yao::Tenant, router.tenant)
-    assert_equal('0123456789abcdef0123456789abcdef', router.tenant.id)
+    router = Yao::Router.new('project_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Project, router.project)
+    assert_equal('0123456789abcdef0123456789abcdef', router.project.id)
 
     assert_requested(stub)
   end

--- a/test/yao/resources/test_security_group.rb
+++ b/test/yao/resources/test_security_group.rb
@@ -25,12 +25,12 @@ class TestSecurityGroup < TestYaoResource
 
   def test_sg_to_tenant
 
-    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/projects/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "0123456789abcdef0123456789abcdef"
           }
         }
@@ -38,9 +38,9 @@ class TestSecurityGroup < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
-    sg = Yao::SecurityGroup.new('tenant_id' => '0123456789abcdef0123456789abcdef')
-    assert_instance_of(Yao::Tenant, sg.tenant)
-    assert_equal('0123456789abcdef0123456789abcdef', sg.tenant.id)
+    sg = Yao::SecurityGroup.new('project_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Project, sg.project)
+    assert_equal('0123456789abcdef0123456789abcdef', sg.project.id)
 
     assert_requested(stub)
   end

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -206,14 +206,14 @@ class TestServer < TestYaoResource
     assert_equal(Yao::Server.method(:list), Yao::Server.method(:list_detail))
   end
 
-  def test_tenant
+  def test_project
 
-    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+    stub = stub_request(:get, "https://example.com:12345/projects/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "0123456789abcdef0123456789abcdef"
           }
         }
@@ -221,9 +221,9 @@ class TestServer < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
-    server = Yao::Server.new('tenant_id' => '0123456789abcdef0123456789abcdef')
-    assert_instance_of(Yao::Tenant, server.tenant)
-    assert_equal('0123456789abcdef0123456789abcdef', server.tenant.id)
+    server = Yao::Server.new('project_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Project, server.project)
+    assert_equal('0123456789abcdef0123456789abcdef', server.project.id)
 
     assert_requested(stub)
   end

--- a/test/yao/resources/test_subnet.rb
+++ b/test/yao/resources/test_subnet.rb
@@ -76,13 +76,13 @@ class TestSubnet < TestYaoResource
     assert_requested(stub)
   end
 
-  def test_tenant
-    stub = stub_request(:get, "https://example.com:12345/tenants/0123456789abcdef0123456789abcdef")
+  def test_project
+    stub = stub_request(:get, "https://example.com:12345/projects/0123456789abcdef0123456789abcdef")
       .to_return(
         status: 200,
         body: <<-JSON,
         {
-          "tenant": {
+          "project": {
             "id": "0123456789abcdef0123456789abcdef"
           }
         }
@@ -90,9 +90,9 @@ class TestSubnet < TestYaoResource
         headers: {'Content-Type' => 'application/json'}
       )
 
-    subnet = Yao::Subnet.new('tenant_id' => '0123456789abcdef0123456789abcdef')
-    assert_instance_of(Yao::Tenant, subnet.tenant)
-    assert_equal('0123456789abcdef0123456789abcdef', subnet.tenant.id)
+    subnet = Yao::Subnet.new('project_id' => '0123456789abcdef0123456789abcdef')
+    assert_instance_of(Yao::Project, subnet.project)
+    assert_equal('0123456789abcdef0123456789abcdef', subnet.project.id)
 
     assert_requested(stub)
   end


### PR DESCRIPTION
keystone v3に移行するためにTenantAssosiationableからProjectAssosiationableに変更する