### PR TITLE
Add update/delete to instance method

### DIFF
--- a/lib/yao/resources/base.rb
+++ b/lib/yao/resources/base.rb
@@ -92,6 +92,18 @@ module Yao::Resources
       end
     end
 
+    # @param resource_params [Hash]
+    # @return [Yao::Resources::*]
+    def update(resource_params)
+      self.class.update(id, resource_params)
+    end
+
+    # @return [String]
+    def destroy
+      self.class.destroy(id)
+    end
+    alias delete destroy
+
     extend RestfullyAccessible
   end
 end

--- a/test/yao/resources/test_base.rb
+++ b/test/yao/resources/test_base.rb
@@ -23,4 +23,25 @@ class TestResourceBase < TestYaoResource
     assert_equal(nil, base.empty)
   end
 
+  def test_update
+    stub(Yao::Resources::Base).update('foo', {name: 'BAR'}) { Yao::Resources::Base.new('id' => 'foo', 'name' => 'BAR')}
+    base = Yao::Resources::Base.new({'id' => 'foo', 'name' => 'bar'})
+    got = base.update(name: 'BAR')
+    assert_equal(got.name, 'BAR')
+  end
+
+  def test_destroy
+    stub(Yao::Resources::Base).destroy('foo') { nil }
+    base = Yao::Resources::Base.new({'id' => 'foo'})
+    got = base.destroy
+    assert_equal(got, nil)
+  end
+
+  def test_delete
+    stub(Yao::Resources::Base).destroy('foo') { nil }
+    base = Yao::Resources::Base.new({'id' => 'foo'})
+    got = base.delete
+    assert_equal(got, nil)
+  end
+
 end


### PR DESCRIPTION
Yao::Resources::* に update/deleteインスタンスメソッドを追加します。
今までクラスメソッドを呼び出していましたが、インスタンスから直接update/deleteできるようになります。
ユースケースととしては以下のような感じです。

```
s = Yao::Server.get("example")

# nameを更新
s.update(name: "example-2")

# 削除
s.delete
```