### PR TITLE
Strictly check resource names

### DIFF
--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -239,7 +239,7 @@ module Yao::Resources
         GET(create_url(name), query)
       rescue => e
         raise e unless e.class == Yao::ItemNotFound || e.class == Yao::NotFound
-        item = find_by_name(name)
+        item = find_by_name(name).select { |r| r.name == name }
         if item.size > 1
           raise Yao::TooManyItemFonud.new("More than one resource exists with the name '#{name}'")
         elsif item.size.zero?

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -156,6 +156,6 @@ class TestRestfullyAccesible < Test::Unit::TestCase
   end
 
   def test_delete
-    assert_equal(Yao::Base.method(:delete), Yao::Base.method(:destroy))
+    assert_equal(Test.method(:delete), Test.method(:destroy))
   end
 end


### PR DESCRIPTION
リソースをgetするときに似たような名前のリソースが複数あるとYao::TooManyItemFonudになる。
例えば、`example` と `exmaple-2` というリソースがある場合発生する。
これはfind_by_nameメソッドでは完全一致ではなくパターンマッチするからである。
find_by_nameから返されるリソースのnameを厳格にチェックすることでこの問題を解決する。