### PR TITLE
support Yao::Server#ports

### DIFF
--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -32,6 +32,11 @@ module Yao::Resources
       Yao::OldSample.list(counter_name, query).select{|os| os.resource_metadata["instance_id"] == id}
     end
 
+    # @return [Array<Yao::Resources::Port>]
+    def ports
+      @ports ||= Yao::Port.list(device_id: id)
+    end
+
     # @param id [String]
     # @return [Hash]
     def self.start(id)

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -227,4 +227,50 @@ class TestServer < TestYaoResource
 
     assert_requested(stub)
   end
+
+  def test_ports
+
+    stub = stub_request(:get, "https://example.com:12345/ports?device_id")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "ports": [{
+            "id": "0123456789abcdef0123456789abcdef"
+          }]
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    server = Yao::Server.new('project_id' => '0123456789abcdef0123456789abcdef')
+    ports  = server.ports
+
+    assert_instance_of(Array, ports)
+    assert_instance_of(Yao::Port, ports.first)
+    assert_equal('0123456789abcdef0123456789abcdef', ports.first.id)
+
+    assert_requested(stub)
+  end
+
+  def test_ports_empty
+
+    stub = stub_request(:get, "https://example.com:12345/ports?device_id")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "ports": []
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    server = Yao::Server.new('project_id' => '0123456789abcdef0123456789abcdef')
+    ports  = server.ports
+
+    assert_instance_of(Array, ports)
+    assert_equal(0, ports.size)
+    assert_requested(stub)
+  end
 end


### PR DESCRIPTION
Yao::Server に port を返すメソッドを追加する PR です

## Usage

以下のようなインタフェースです

```ruby
server =  Yao::Server.get("wazuh-master-1.pepabo.com")

# return Array<Yao::Resources::Port>
server.ports
```