### PR TITLE
add Yao::Port#floating_ip, Yao::Port#has_floating_ip?

### DIFF
--- a/lib/yao/resources/port.rb
+++ b/lib/yao/resources/port.rb
@@ -19,6 +19,22 @@ module Yao::Resources
       @subnet ||= Yao::Subnet.find fixed_ips.first["subnet_id"]
     end
 
+    # @return [Yao::FloatingIP]
+    def floating_ip
+      # notice: port が floating_ip を持たない場合has_floating_ip? を呼び出す度に
+      # Yao::FloatingIP.list を評価しなくていいように defined? を入れている
+      if defined?(@floating_ip)
+        @floating_ip
+      else
+        @floating_ip = Yao::FloatingIP.list(port_id: id).first
+      end
+    end
+
+    # @return [Bool]
+    def has_floating_ip?
+      !!floating_ip
+    end
+
     self.service        = "network"
     self.resource_name  = "port"
     self.resources_name = "ports"

--- a/test/yao/resources/test_port.rb
+++ b/test/yao/resources/test_port.rb
@@ -170,4 +170,52 @@ class TestPort < TestYaoResource
 
     assert_requested(stub)
   end
+
+  def test_floating_ip
+
+    stub = stub_request(:get, "https://example.com:12345/floatingips?port_id")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "floatingips": [{
+            "id": "00000000-0000-0000-0000-000000000000"
+          }]
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    params = {
+      "port_id" => "00000000-0000-0000-0000-000000000000",
+    }
+
+    port = Yao::Port.new(params)
+    assert_instance_of(Yao::FloatingIP, port.floating_ip)
+    assert_true(port.has_floating_ip?)
+    assert_requested(stub)
+  end
+
+  def test_floating_ip_empty
+
+    stub = stub_request(:get, "https://example.com:12345/floatingips?port_id")
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "floatingips": []
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    params = {
+      "port_id" => "00000000-0000-0000-0000-000000000000",
+    }
+
+    port = Yao::Port.new(params)
+    assert_nil(port.floating_ip)
+    assert_false(port.has_floating_ip?)
+    assert_requested(stub)
+  end
 end


### PR DESCRIPTION
Yao::Port#floating_ip, Yao::Port#has_floating_ip? を追加する PR です

## Sample Usage

```ruby
server = Yao::Server.find("foobar")
server.ports.each { |port|
  if port.has_floating_ip?
    # port.floating_ip で何かする
  end
}
```

