### PR TITLE
add methods {associate, disassociate } Yao::FloatingIP with Yao::Port

### DIFF
--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -36,13 +36,6 @@ module Yao::Resources
       # @param port_id [String] ID of port
       # @return [Yao::Resources::FloatingIP]
       def associate_port(id, port_id)
-
-        param = {
-          floatingip: {
-            port_id: port_id
-          }
-        }
-
         update(id, port_id: port_id)
       end
 

--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -18,5 +18,48 @@ module Yao::Resources
     def router
       @router ||= Yao::Router.get(router_id)
     end
+
+    # @param [Yao::Resources::Port]
+    # @return [Yao::Resources::FloatingIP]
+    def associate_port(port)
+      self.class.associate_port(id, port.id)
+    end
+
+    # @return [Yao::Resources::FloatingIP]
+    def disassociate_port
+      self.class.disassociate_port(id)
+    end
+
+    class << self
+
+      # @param id [String] ID of floating_ip
+      # @param port_id [String] ID of port
+      # @return [Yao::Resources::FloatingIP]
+      def associate_port(id, port_id)
+
+        param = {
+          floatingip: {
+            port_id: port_id
+          }
+        }
+
+        res = PUT([resources_path, id ].join('/'), param.to_json)
+        resource_from_json(res.body)
+      end
+
+      # @param id [String] ID of floating_ip
+      # @return [Yao::Resources::FloatingIP]
+      def disassociate_port(id)
+
+        param = {
+          floatingip: {
+            port_id: nil
+          }
+        }
+
+        res = PUT([resources_path, id].join('/'), param.to_json)
+        resource_from_json(res.body)
+      end
+    end
   end
 end

--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -42,15 +42,7 @@ module Yao::Resources
       # @param id [String] ID of floating_ip
       # @return [Yao::Resources::FloatingIP]
       def disassociate_port(id)
-
-        param = {
-          floatingip: {
-            port_id: nil
-          }
-        }
-
-        res = PUT([resources_path, id].join('/'), param.to_json)
-        resource_from_json(res.body)
+        update(id, port_id: nil)
       end
     end
   end

--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -43,8 +43,7 @@ module Yao::Resources
           }
         }
 
-        res = PUT([resources_path, id ].join('/'), param.to_json)
-        resource_from_json(res.body)
+        update(id, port_id: port_id)
       end
 
       # @param id [String] ID of floating_ip

--- a/test/yao/resources/test_floating_ip.rb
+++ b/test/yao/resources/test_floating_ip.rb
@@ -131,4 +131,95 @@ class TestFloatingIP < TestYaoResource
 
     assert_requested(stub)
   end
+
+  def test_associate_port
+
+    floating_ip = Yao::FloatingIP.new("id" => "00000000-0000-0000-0000-000000000000")
+    port = Yao::Port.new("id" => "01234567-0123-0123-0123-0123456789ab")
+
+    stub = stub_request(:put, "https://example.com:12345/floatingips/00000000-0000-0000-0000-000000000000").
+      with(
+        body: '{"floatingip":{"port_id":"01234567-0123-0123-0123-0123456789ab"}}'
+      )
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "floatingip": {
+            "id": "00000000-0000-0000-0000-000000000000"
+          }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    resource = Yao::FloatingIP.associate_port(floating_ip.id, port.id)
+    assert_instance_of(Yao::FloatingIP, resource)
+    assert_equal("00000000-0000-0000-0000-000000000000", resource.id)
+
+    assert_requested(stub)
+  end
+
+  sub_test_case 'Yao::FloatingIP#associate_port' do
+
+    def setup
+      stub(Yao::Resources::FloatingIP).associate_port {}
+    end
+
+    def test_associate_port
+      floating_ip = Yao::FloatingIP.new("id" => "00000000-0000-0000-0000-000000000000")
+      port = Yao::Port.new("id" => "01234567-0123-0123-0123-0123456789ab")
+
+      floating_ip.associate_port(port)
+
+      assert_received(Yao::Resources::FloatingIP) { |subject|
+        subject.associate_port(floating_ip.id, port.id)
+      }
+    end
+  end
+
+  def test_disassociate_port
+
+    stub = stub_request(:put, "https://example.com:12345/floatingips/00000000-0000-0000-0000-000000000000").
+      with(
+        body: '{"floatingip":{"port_id":null}}'
+      )
+      .to_return(
+        status: 200,
+        body: <<-JSON,
+        {
+          "floatingip": {
+            "id": "00000000-0000-0000-0000-000000000000"
+          }
+        }
+        JSON
+        headers: {'Content-Type' => 'application/json'}
+      )
+
+    floating_ip = Yao::FloatingIP.new("id" => "00000000-0000-0000-0000-000000000000")
+
+    resource = Yao::FloatingIP.disassociate_port(floating_ip.id)
+    assert_instance_of(Yao::FloatingIP, resource)
+    assert_equal("00000000-0000-0000-0000-000000000000", resource.id)
+
+    assert_requested(stub)
+  end
+
+  sub_test_case 'Yao::FloatingIP#disassociate_port' do
+
+    def setup
+      stub(Yao::Resources::FloatingIP).disassociate_port {}
+    end
+
+    def test_associate_port
+      floating_ip = Yao::FloatingIP.new("id" => "00000000-0000-0000-0000-000000000000")
+      port = Yao::Port.new("id" => "01234567-0123-0123-0123-0123456789ab")
+
+      floating_ip.disassociate_port
+
+      assert_received(Yao::Resources::FloatingIP) { |subject|
+        subject.disassociate_port(floating_ip.id)
+      }
+    end
+  end
 end


### PR DESCRIPTION
Yao::Port に Yao::FloatingIP をくっつけるメソッドを足します

## sample usage

```ruby
# port に FIP 付与済み
server = Yao::Server.find("foobar")

server.ports.each { |port|
  floating_ip = port.floating_ip

  # いわゆる 「 FIP を外す」
  puts floating_ip.disassociate_port

  # いわゆる 「 FIP をつける」
  puts floating_ip.associate_port(port)
}
```

## ディスカッションしたい点

https://docs.openstack.org/api-ref/network/v2/?expanded=update-floating-ip-detail#update-floating-ip のドキュメントを参考しにして `associate` `disassociate` というメソッド名を選択しました。

別に `add` `remove` 等の名称でもいい気がするので レビューお願いします〜
