### PR TITLE
Fix invalid request with empty or nil

### DIFF
--- a/lib/yao/error.rb
+++ b/lib/yao/error.rb
@@ -2,6 +2,7 @@ module Yao
   class ReadOnlyViolationError < ::StandardError; end
   class TooManyItemFonud       < ::StandardError; end
   class InvalidResponse        < ::StandardError; end
+  class InvalidRequest         < ::StandardError; end
 
   class ServerError < ::StandardError
     def initialize(message, requested_env)

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -131,7 +131,7 @@ module Yao::Resources
     # @param query [Hash]
     # @return [Yao::Resources::*]
     def get(id_or_name_or_permalink, query={})
-      res = if id_or_name_or_permalink.start_with?("http://", "https://")
+      res = if id_or_name_or_permalink&.start_with?("http://", "https://")
               GET(id_or_name_or_permalink, query)
             elsif uuid?(id_or_name_or_permalink)
               GET(create_url(id_or_name_or_permalink), query)
@@ -148,7 +148,7 @@ module Yao::Resources
     # @return [Yao::Resources::*]
     def get!(id_or_name_or_permalink, query={})
       get(id_or_name_or_permalink, query)
-    rescue Yao::ItemNotFound, Yao::NotFound, Yao::InvalidResponse
+    rescue Yao::ItemNotFound, Yao::NotFound, Yao::InvalidResponse, Yao::InvalidRequest
       nil
     end
 
@@ -234,6 +234,11 @@ module Yao::Resources
     # @param query [Hash]
     # @return [Yao::Resources::*]
     def get_by_name(name, query={})
+
+      # 空またnilの場合listと同じURLにリクエストしてしまい意図しないレスポンスが返ってくる
+      if name.nil? || name.empty?
+        raise Yao::InvalidRequest.new("Invalid request with empty name or nil")
+      end
 
       begin
         GET(create_url(name), query)

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -139,6 +139,18 @@ class TestRestfullyAccesible < Test::Unit::TestCase
 
       assert_equal(uuid, Test.send(:get_by_name, 'dummy').body[@resource_name]['id'])
     end
+
+    test 'empty name' do
+      assert_raise(Yao::InvalidRequest, "Invalid requeset with empty name or nil") do
+        Test.send(:get_by_name, '')
+      end
+    end
+
+    test 'nil' do
+      assert_raise(Yao::InvalidRequest, "Invalid requeset with empty name or nil") do
+        Test.send(:get_by_name, nil)
+      end
+    end
   end
 
   def test_find_by_name


### PR DESCRIPTION
getメソッドを空またはnilで呼び出すと `@data` が nilのインスタンスができてしまう。

```
yrb(main):002:0> Yao::Server.get("")
=> #<Yao::Resources::Server:0x00007f8323cec810 @data=nil>
```

これはlistメソッドと同じURLを叩いてしまい、意図しないレスポンスを受け取っているからである。
このPRではこの問題を解決します。

get_by_nameに空またはnilが渡されるとYao::InvalidRequestをraiseします。
なぜraiseするかというとgetメソッドは、リソースが見つからなかった場合raiseすることを期待されていて、get!はnilを返すことを期待しているためです。