### PR TITLE
Replace InvalidResponse to Yao::ItemNotFound

### DIFF
--- a/lib/yao/error.rb
+++ b/lib/yao/error.rb
@@ -1,7 +1,6 @@
 module Yao
   class ReadOnlyViolationError < ::StandardError; end
   class TooManyItemFonud       < ::StandardError; end
-  class InvalidResponse        < ::StandardError; end
   class InvalidRequest         < ::StandardError; end
 
   class ServerError < ::StandardError

--- a/lib/yao/resources/restfully_accessible.rb
+++ b/lib/yao/resources/restfully_accessible.rb
@@ -148,7 +148,7 @@ module Yao::Resources
     # @return [Yao::Resources::*]
     def get!(id_or_name_or_permalink, query={})
       get(id_or_name_or_permalink, query)
-    rescue Yao::ItemNotFound, Yao::NotFound, Yao::InvalidResponse, Yao::InvalidRequest
+    rescue Yao::ItemNotFound, Yao::NotFound, Yao::InvalidRequest
       nil
     end
 
@@ -242,13 +242,12 @@ module Yao::Resources
 
       begin
         GET(create_url(name), query)
-      rescue => e
-        raise e unless e.class == Yao::ItemNotFound || e.class == Yao::NotFound
+      rescue Yao::ItemNotFound, Yao::NotFound => e
         item = find_by_name(name).select { |r| r.name == name }
         if item.size > 1
           raise Yao::TooManyItemFonud.new("More than one resource exists with the name '#{name}'")
         elsif item.size.zero?
-          raise Yao::InvalidResponse.new("No resource exists with the name '#{name}'")
+          raise e
         end
         GET(create_url(item.first.id), query)
       end

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -140,6 +140,21 @@ class TestRestfullyAccesible < Test::Unit::TestCase
       assert_equal(uuid, Test.send(:get_by_name, 'dummy').body[@resource_name]['id'])
     end
 
+    test 'multiple same name found' do
+      name = 'dummy'
+      uuid = '00112233-4455-6677-8899-aabbccddeeff'
+      list_body = { @resources_name => [
+        { 'name' => 'dummy', 'id' => uuid },
+        { 'name' => 'dummy', 'id' => '308cb410-9c84-40ec-a3eb-583001aaa7fd' }
+      ]}
+      stub1 = stub_get_request_not_found([@url, @resources_name, name].join('/'))
+      stub2 = stub_get_request_with_json_response([@url, "#{@resources_name}?name=#{name}"].join('/'), list_body)
+
+      assert_raise(Yao::TooManyItemFonud, "More than one resource exists with the name '#{name}'") do
+        Test.send(:get_by_name, name)
+      end
+    end
+
     test 'empty name' do
       assert_raise(Yao::InvalidRequest, "Invalid requeset with empty name or nil") do
         Test.send(:get_by_name, '')

--- a/test/yao/resources/test_restfully_accessible.rb
+++ b/test/yao/resources/test_restfully_accessible.rb
@@ -88,7 +88,7 @@ class TestRestfullyAccesible < Test::Unit::TestCase
       stub_get_request_not_found([@url, @resources_name, name].join('/'))
       stub_get_request_with_json_response([@url, "#{@resources_name}?name=#{name}"].join('/'), body)
 
-      assert_raise(Yao::InvalidResponse, "raise proper exception") do
+      assert_raise(Yao::ItemNotFound, "raise proper exception") do
         Test.get(name)
       end
     end
@@ -149,6 +149,19 @@ class TestRestfullyAccesible < Test::Unit::TestCase
     test 'nil' do
       assert_raise(Yao::InvalidRequest, "Invalid requeset with empty name or nil") do
         Test.send(:get_by_name, nil)
+      end
+    end
+
+    test 'not found' do
+      name = "dummy"
+      uuid = "00112233-4455-6677-8899-aabbccddeeff"
+      body = {@resources_name => []}
+
+      stub1 = stub_get_request_not_found([@url, @resources_name, name].join('/'))
+      stub2 = stub_get_request_with_json_response([@url, "#{@resources_name}?name=#{name}"].join('/'), body)
+
+      assert_raise(Yao::ItemNotFound) do
+        Test.send(:get_by_name, name)
       end
     end
   end


### PR DESCRIPTION
getメソッドを実行したときにリソースが見つからないとYao::InvalidResponseを返していました。
しかし、Yao::ItemNotFoundを返すのがより適切だと思い変更します。

(過去の私はraiseをカスケードする仕方がわからず、Yao::InvalidResponseを作って回避したのでした…)