### PR TITLE
Strict instantiation methods.

### DIFF
--- a/lib/yao/resources/aggregates.rb
+++ b/lib/yao/resources/aggregates.rb
@@ -4,10 +4,9 @@ module Yao::Resources
   class Aggregates < Base
     friendly_attributes :availability_zone, :deleted, :hosts, :metadata, :name
 
-    # @return [Date]
-    def deleted_at
-      Date.parse(self["deleted_at"]) if self["deleted_at"]
-    end
+    map_attributes_to_time :created_at, :updated_at, :deleted_at
+    alias :created :created_at
+    alias :updated :updated_at
 
     self.service        = "compute"
     self.resources_name = "aggregates"

--- a/lib/yao/resources/base.rb
+++ b/lib/yao/resources/base.rb
@@ -66,6 +66,7 @@ module Yao::Resources
     # @return [Symbol]
     def self.map_attributes_to_time(*names)
       names.map(&:to_s).each do |name|
+        add_instantiation_name_list(name)
         define_method(name) do
           Time.parse(self[name])
         end

--- a/lib/yao/resources/base.rb
+++ b/lib/yao/resources/base.rb
@@ -82,7 +82,7 @@ module Yao::Resources
     # @param name [String]
     # @return [String]
     def [](name)
-      if !@data.key?(name) && self.class.instantiation?(name)
+      if @data["id"] && !@data.key?(name) && self.class.instantiation?(name)
         @data = self.class.get(@data["id"]).to_hash
       end
       @data[name]

--- a/lib/yao/resources/base.rb
+++ b/lib/yao/resources/base.rb
@@ -62,6 +62,16 @@ module Yao::Resources
       end
     end
 
+    # @param names [Array<Symbol>]
+    # @return [Symbol]
+    def self.map_attributes_to_time(*names)
+      names.map(&:to_s).each do |name|
+        define_method(name) do
+          Time.parse(self[name])
+        end
+      end
+    end
+
     # @param data_via_json [Hash]
     # @return [Hash]
     def initialize(data_via_json)
@@ -92,20 +102,6 @@ module Yao::Resources
     # @return [String]
     def id
       self["id"]
-    end
-
-    # @return [Date]
-    def created
-      if date = self["created_at"] || self["created"]
-        Time.parse(date)
-      end
-    end
-
-    # @return [Date]
-    def updated
-      if date = self["updated_at"] || self["updated"]
-        Time.parse(date)
-      end
     end
 
     # @param resource_params [Hash]

--- a/lib/yao/resources/compute_services.rb
+++ b/lib/yao/resources/compute_services.rb
@@ -2,6 +2,9 @@ module Yao::Resources
   class ComputeServices < Base
     friendly_attributes  :status, :binary, :host, :zone, :state, :disabled_reason, :forced_down
 
+    map_attributes_to_time :updated_at
+    alias :updated :updated_at
+
     self.service        = "compute"
     self.resource_name  = "service"
     self.resources_name = "os-services"

--- a/lib/yao/resources/floating_ip.rb
+++ b/lib/yao/resources/floating_ip.rb
@@ -10,6 +10,10 @@ module Yao::Resources
                         :floating_ip_address,
                         :status, :port_details, :tags, :port_forwardings
 
+    map_attributes_to_time :created_at, :updated_at
+    alias :created :created_at
+    alias :updated :updated_at
+
     self.service        = "network"
     self.resource_name  = "floatingip"
     self.resources_name = "floatingips"

--- a/lib/yao/resources/loadbalancer.rb
+++ b/lib/yao/resources/loadbalancer.rb
@@ -6,6 +6,10 @@ module Yao::Resources
     map_attribute_to_resources listeners: LoadBalancerListener
     map_attribute_to_resources pools: LoadBalancerPool
 
+    map_attributes_to_time :created_at, :updated_at
+    alias :created :created_at
+    alias :updated :updated_at
+
     # @return [Yao::Resources::Tenant]
     def project
       if project_id = self["project_id"]

--- a/lib/yao/resources/loadbalancer_healthmonitor.rb
+++ b/lib/yao/resources/loadbalancer_healthmonitor.rb
@@ -7,6 +7,10 @@ module Yao::Resources
 
     map_attribute_to_resources pools: LoadBalancerListener
 
+    map_attributes_to_time :created_at, :updated_at
+    alias :created :created_at
+    alias :updated :updated_at
+
     # @return [Date]
     def created_at
       Date.parse(self["created_at"])

--- a/lib/yao/resources/loadbalancer_listener.rb
+++ b/lib/yao/resources/loadbalancer_listener.rb
@@ -8,6 +8,10 @@ module Yao::Resources
 
     map_attribute_to_resources loadbalancers: LoadBalancer
 
+    map_attributes_to_time :created_at, :updated_at
+    alias :created :created_at
+    alias :updated :updated_at
+
     # @return [Yao::Resources::Tenant]
     def project
       if project_id = self["project_id"]

--- a/lib/yao/resources/loadbalancer_pool.rb
+++ b/lib/yao/resources/loadbalancer_pool.rb
@@ -7,6 +7,10 @@ module Yao::Resources
     map_attribute_to_resources loadbalancers: LoadBalancer
     map_attribute_to_resources listeners: LoadBalancerListener
 
+    map_attributes_to_time :created_at, :updated_at
+    alias :created :created_at
+    alias :updated :updated_at
+
     # @return [Yao::Resources::LoadBalancerListener]
     def listeners
       @listeners ||= self["listeners"].map do |listener|

--- a/lib/yao/resources/loadbalancer_pool_member.rb
+++ b/lib/yao/resources/loadbalancer_pool_member.rb
@@ -5,6 +5,10 @@ module Yao::Resources
                         :monitor_address, :address,
                         :protocol_port, :operating_status
 
+    map_attributes_to_time :created_at, :updated_at
+    alias :created :created_at
+    alias :updated :updated_at
+
     # @return [Yao::Resources::Tenant]
     def project
       if project_id = self["project_id"]

--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -20,6 +20,10 @@ module Yao::Resources
     map_attribute_to_attribute 'OS-EXT-STS:task_state'               => :ext_sts_task_state
     map_attribute_to_attribute 'OS-EXT-STS:vm_state'                 => :ext_sts_vm_state
 
+    map_attributes_to_time :created, :updated
+    alias :created_at :created
+    alias :updated_at :updated
+
     self.service        = "compute"
     self.resource_name  = "server"
     self.resources_name = "servers"

--- a/test/yao/resources/test_aggregates.rb
+++ b/test/yao/resources/test_aggregates.rb
@@ -19,6 +19,6 @@ class TestAggregates < TestYaoResource
     assert_equal("nova", aggregates.name)
     assert_equal(Time.parse("2015-08-27T09:49:58-05:00"), aggregates.created)
     assert_equal(Time.parse("2015-08-27T09:49:58-05:00"), aggregates.updated)
-    assert_equal(Date.parse("2015-08-27T09:49:58-05:00"), aggregates.deleted_at)
+    assert_equal(Time.parse("2015-08-27T09:49:58-05:00"), aggregates.deleted_at)
   end
 end


### PR DESCRIPTION
#183 で各メソッドにアクセスする際にインスタンス化する処理を追加した。
しかしながら、実際にAPIが返さない情報もインスタンス化しようとしてしまい不都合が起きる場合があった。
(e.g. Yao::Server.created)
インスタンス化するメソッドを限定し、この問題を解決します。

OpenStackのプロジェクトによりcreated/created_at, updated/updated_atの表記揺れがありそれの解消も行っています。
範囲が大きいので、このPRではtestでコケたリソースのみ修正してします。