### PR TITLE
Add live_migrate method

### DIFF
--- a/lib/yao/resources/server.rb
+++ b/lib/yao/resources/server.rb
@@ -68,6 +68,16 @@ module Yao::Resources
       self.class.resize(id, flavor_id)
     end
 
+    # @param id [String]
+    # @param host [String]
+    # @param block_migration [Boolean]
+    # @param disk_over_commit [Boolean]
+    # @param opts [Hash]
+    # @return [Hash]
+    def live_migrate(host = nil, block_migration = false, disk_over_commit = false, opts = {})
+      self.class.live_migrate(id, host, block_migration, disk_over_commit, opts)
+    end
+
     # @return [Hash]
     def add_security_group(sg_name)
       self.class.add_security_group(id, sg_name)
@@ -100,6 +110,21 @@ module Yao::Resources
     # @return [Hash]
     def self.resize(id, flavor_id)
       action(id,"resize" => { "flavorRef" => flavor_id })
+    end
+
+    # @param id [String]
+    # @param host [String]
+    # @param block_migration [Boolean]
+    # @param disk_over_commit [Boolean]
+    # @param opts [Hash]
+    # @return [Hash]
+    def self.live_migrate(id, host = nil, block_migration = false, disk_over_commit = false, opts ={})
+      query = {
+        "host" => host,
+        "block_migration" => block_migration,
+        "disk_over_commit" => disk_over_commit,
+      }.merge(opts)
+      action(id, "os-migrateLive" => query)
     end
 
     # @param id [String]

--- a/test/yao/resources/test_server.rb
+++ b/test/yao/resources/test_server.rb
@@ -320,6 +320,21 @@ class TestServer < TestYaoResource
     assert_requested(stub)
   end
 
+  def test_live_migrate
+    server_id = '2ce4c5b3-2866-4972-93ce-77a2ea46a7f9'
+    stub = stub_post_request(
+      "https://example.com:12345/servers/#{server_id}/action",
+      [{"os-migrateLive": {
+          "host": "test-node-1",
+          "block_migration": false,
+          "disk_over_commit": false
+        }}]
+    )
+
+    Yao::Server.new('id' => server_id).live_migrate("test-node-1", false, false)
+    assert_requested(stub)
+  end
+
   def test_add_security_group
     server_id = '2ce4c5b3-2866-4972-93ce-77a2ea46a7f9'
     stub = stub_post_request(


### PR DESCRIPTION
live-migrateを行うメソッドを追加します
https://docs.openstack.org/api-ref/compute/?expanded=migrate-server-migrate-action-detail,live-migrate-server-os-migratelive-action-detail#live-migrate-server-os-migratelive-action