### PR TITLE
Add created_at/updated_at method to Yao::Volume

### DIFF
--- a/lib/yao/resources/volume.rb
+++ b/lib/yao/resources/volume.rb
@@ -10,6 +10,10 @@ module Yao::Resources
     map_attribute_to_attribute 'os-vol-host-attr:host' => :host
     map_attribute_to_attribute 'os-vol-tenant-attr:tenant_id' => :tenant_id
 
+    map_attributes_to_time :created_at, :updated_at
+    alias :created :created_at
+    alias :updated :updated_at
+
     self.service        = "volumev3"
     self.resource_name  = "volume"
     self.resources_name = "volumes"

--- a/test/yao/resources/test_volume.rb
+++ b/test/yao/resources/test_volume.rb
@@ -13,7 +13,9 @@ class TestVolume < TestYaoResource
         'snapshot_id' => nil,
         'status' => 'available',
         'user_id' => 'aaaa166533fd49f3b11b1cdce2430000',
-        'volume_type' => 'test'
+        'volume_type' => 'test',
+        'created_at' => '2018-11-28T06:25:15.288987',
+        'updated_at' => '2019-11-28T06:25:15.288987'
     }
 
     volume = Yao::Volume.new(params)
@@ -30,6 +32,10 @@ class TestVolume < TestYaoResource
     assert_equal(volume.user_id, 'aaaa166533fd49f3b11b1cdce2430000')
     assert_equal(volume.volume_type, 'test')
     assert_equal(volume.type, 'test')
+    assert_equal(Time.parse('2018-11-28T06:25:15.288987'), volume.created_at)
+    assert_equal(Time.parse('2018-11-28T06:25:15.288987'), volume.created)
+    assert_equal(Time.parse('2019-11-28T06:25:15.288987'), volume.updated_at)
+    assert_equal(Time.parse('2019-11-28T06:25:15.288987'), volume.updated)
   end
 
   def test_list


### PR DESCRIPTION
Yao::Volumeにcreate_at/updated_atを追加します。
過去に存在していましたが、 https://github.com/yaocloud/yao/pull/199 のときに追加わすれたようです。

過去の互換性のために created/updated メソッドも追加しています。