### PR TITLE
Change to return Yao::Subnet

### DIFF
--- a/lib/yao/resources/network.rb
+++ b/lib/yao/resources/network.rb
@@ -2,7 +2,7 @@ module Yao::Resources
   class Network < Base
     include ProjectAssociationable
 
-    friendly_attributes :name, :status, :shared, :subnets, :admin_state_up
+    friendly_attributes :name, :status, :shared, :admin_state_up
     map_attribute_to_attribute "provider:physical_network" => :physical_network
     map_attribute_to_attribute "provider:network_type"     => :type
     map_attribute_to_attribute "provider:segmentation_id"  => :segmentation_id
@@ -16,6 +16,11 @@ module Yao::Resources
     # @return [Array<Yao::Resources::Port>]
     def ports
       @ports ||= Yao::Port.list(network_id: id)
+    end
+
+    # @return [Array<Yao::Resources::Subnet>]
+    def subnets
+      @subnets ||= self['subnets'].map {|id| Yao::Subnet.new("id" => id)}
     end
   end
 end

--- a/test/yao/resources/test_network.rb
+++ b/test/yao/resources/test_network.rb
@@ -14,7 +14,7 @@ class TestNetwork < TestYaoResource
       "router:external" => false,
       "shared" => false,
       "status" => "ACTIVE",
-      "subnets" => [],
+      "subnets" => ["52822b63-eb89-496d-9509-f91473b9d85d"],
       "tenant_id" => "c05140b3dc7c4555afff9fab6b58edc2",
       "project_id" => "c05140b3dc7c4555afff9fab6b58edc2",
     }
@@ -28,13 +28,15 @@ class TestNetwork < TestYaoResource
     assert_equal(false, network.shared)
     assert_equal(false, network.shared?)
     assert_equal("c05140b3dc7c4555afff9fab6b58edc2", network.tenant_id)
-    assert_equal([], network.subnets)
     assert_equal(true, network.admin_state_up)
 
     #map_attribute_to_attribute
     assert_equal("physnet1", network.physical_network)
     assert_equal("vlan", network.type)
     assert_equal(1000, network.segmentation_id)
+
+    assert_equal(Yao::Subnet, network.subnets.first.class)
+    assert_equal("52822b63-eb89-496d-9509-f91473b9d85d", network.subnets.first.id)
   end
 
   def test_project


### PR DESCRIPTION
Yao::Network#subnetsが返すオブジェクトをArray[String]からArray[Yao::Subnet]に変更します。
これにより↓みたいなことができるようになります。

```
[1] yao(main)> Yao::Network.list.first.subnets.first.name
=> "example-subnet"
```