### PR TITLE
Fixed an error that occurs when nil is passed

### DIFF
--- a/lib/yao/resources/base.rb
+++ b/lib/yao/resources/base.rb
@@ -68,7 +68,8 @@ module Yao::Resources
       names.map(&:to_s).each do |name|
         add_instantiation_name_list(name)
         define_method(name) do
-          Time.parse(self[name])
+          time = self[name]
+          Time.parse(time) if time
         end
       end
     end

--- a/test/yao/resources/test_base.rb
+++ b/test/yao/resources/test_base.rb
@@ -23,6 +23,16 @@ class TestResourceBase < TestYaoResource
     assert_equal(nil, base.empty)
   end
 
+  def test_map_attributes_to_time
+    base = Yao::Resources::Base.new("updated_at" => "2015-01-01T00:00:00Z")
+    base.class.map_attributes_to_time :updated_at
+    assert_equal(Time.parse("2015-01-01T00:00:00Z"), base.updated_at)
+
+    base = Yao::Resources::Base.new("updated_at" => nil)
+    base.class.map_attributes_to_time :updated_at
+    assert(base.updated_at.nil?)
+  end
+
   def test_update
     stub(Yao::Resources::Base).update('foo', {name: 'BAR'}) { Yao::Resources::Base.new('id' => 'foo', 'name' => 'BAR')}
     base = Yao::Resources::Base.new({'id' => 'foo', 'name' => 'bar'})


### PR DESCRIPTION
リソースによってはattributeがnilであることがあり、そのときにエラーになるので修正した。

e.g:
```
#<Yao::Resources::Volume:0x00007f3f31f70fe0
 @data=
  {"migration_status"=>nil,
   "attachments"=>[],
   "links"=>
--snip --
   "os-vol-host-attr:host"=>nil,
   "encrypted"=>false,
   "updated_at"=>nil, 👈
-- snip --
```