### PR TITLE
Fix broken hyperlink on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ end
 
 ## Support policy
 
-YAO supports rubies which are supported by Ruby Core Team. Please look into [`.travis.yml`](./.travis.yml) 's directive.
+YAO supports rubies which are supported by Ruby Core Team. Please look into [CI](./.github/workflows/ubuntu.yml)'s directive.
 
 If you want to use YAO's full functionality, e.g Ruby 2.3 or below, please create an issue or a PR first (PR Recommended ;) ).
 


### PR DESCRIPTION
Since e3cef2a85cbd4dde18ff1a8ea6b5cc3f036ef4a5, GitHub Actions is used.

At 5bff335ca9b5e3502aac87fcf244109f130792d4, `.travis.yml` was removed.
